### PR TITLE
Bump to SBT 1.9, bump libraries, remove deprecations.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,24 @@ lazy val commonSettings: Seq[Setting[_]] = Def.settings(
   Compile / javacOptions ++= Seq(
     "-encoding", "UTF-8", "-Xlint:all", "-Xlint:-processing", "-source", "1.8", "-target", "1.8"
   ),
-  Compile / doc / javacOptions := Seq("-encoding", "UTF-8", "-source", "1.8")
+  Compile / doc / javacOptions := Seq("-encoding", "UTF-8", "-source", "1.8"),
+  homepage := Some(url("https://github.com/maichler/sbt-jupiter-interface")),
+  licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
+  organization := "net.aichler",
+  scalaVersion := Versions.scala,
+  usePgpKeyHex("4944210D30F5FBFC1D57957908C33DB0CBC4CC5A"),
+  publishMavenStyle := true,
+  sonatypeProfileName := "net.aichler",
+  sonatypeProjectHosting := Some(GitHubHosting("maichler", "sbt-jupiter-interface", "maichler@gmail.com")),
+  developers := List(
+    Developer(id = "maichler", name = "Michael Aichler", email = "maichler@gmail.com", url = url("https://github.com/maichler"))
+  ),
+  scmInfo := Some(
+    ScmInfo(
+      url("https://github.com/maichler/sbt-jupiter-interface"),
+      "scm:git@github.com:maichler/sbt-jupiter-interface.git"
+    )
+  )
 )
 
 lazy val library = (project in file("src/library"))
@@ -86,27 +103,6 @@ lazy val root = (project in file("."))
   .settings(
     name := "jupiter-root",
     publishTo := sonatypePublishTo.value
-  )
-  .settings(
-    inThisBuild(Seq(
-      homepage := Some(url("https://github.com/maichler/sbt-jupiter-interface")),
-      licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
-      organization := "net.aichler",
-      scalaVersion := Versions.scala,
-      usePgpKeyHex("4944210D30F5FBFC1D57957908C33DB0CBC4CC5A"),
-      publishMavenStyle := true,
-      sonatypeProfileName := "net.aichler",
-      sonatypeProjectHosting := Some(GitHubHosting("maichler", "sbt-jupiter-interface", "maichler@gmail.com")),
-      developers := List(
-        Developer(id = "maichler", name = "Michael Aichler", email = "maichler@gmail.com", url = url("https://github.com/maichler"))
-      ),
-      scmInfo := Some(
-        ScmInfo(
-          url("https://github.com/maichler/sbt-jupiter-interface"),
-          "scm:git@github.com:maichler/sbt-jupiter-interface.git"
-        )
-      )
-    ))
   )
   .settings(
     releaseTagName := (ThisBuild / version).value,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.8.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,3 @@
-libraryDependencies ++= Seq(
-  "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
-)
-
-resolvers += Resolver.typesafeIvyRepo("releases")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
-
-// For sbt 0.13.x (upto sbt-sonatype 2.3)
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/src/library/src/main/java/net/aichler/jupiter/api/JupiterTestFingerprint.java
+++ b/src/library/src/main/java/net/aichler/jupiter/api/JupiterTestFingerprint.java
@@ -20,6 +20,8 @@ package net.aichler.jupiter.api;
 
 import sbt.testing.AnnotatedFingerprint;
 
+import java.util.Objects;
+
 /**
  * A dummy fingerprint implementation used for all discovered tests.
  *
@@ -32,7 +34,6 @@ public class JupiterTestFingerprint implements AnnotatedFingerprint {
      */
     @Override
     public boolean isModule() {
-
         return false;
     }
 
@@ -42,13 +43,11 @@ public class JupiterTestFingerprint implements AnnotatedFingerprint {
      */
     @Override
     public String annotationName() {
-
         return getClass().getName();
     }
 
     @Override
     public boolean equals(Object obj) {
-
         if (obj instanceof AnnotatedFingerprint) {
             AnnotatedFingerprint f = (AnnotatedFingerprint) obj;
             if (annotationName().equals(f.annotationName())) {
@@ -57,5 +56,10 @@ public class JupiterTestFingerprint implements AnnotatedFingerprint {
         }
 
         return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.annotationName(), this.isModule());
     }
 }

--- a/src/library/src/main/java/net/aichler/jupiter/internal/event/LoggingEventHandler.java
+++ b/src/library/src/main/java/net/aichler/jupiter/internal/event/LoggingEventHandler.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 /**
  * Writes dispatch events to a file for testing/debugging purposes.
  *
- * <h3>Example Usage</h3>
+ * <h2>Example Usage</h2>
  * <pre>{@code
  *   SBT> testOnly -- --trace-dispatch-events
  * }

--- a/src/library/src/test/java/jupiter/samples/VintageParameterizedTests.java
+++ b/src/library/src/test/java/jupiter/samples/VintageParameterizedTests.java
@@ -5,8 +5,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 /**
  * Sample test methods for the vintage-engine using {@link Parameterized} runner.
@@ -18,7 +18,6 @@ public class VintageParameterizedTests {
     private final int code;
 
     public VintageParameterizedTests(char alpha, int number) {
-
         this.alpha = alpha;
         this.code = number;
     }
@@ -34,7 +33,6 @@ public class VintageParameterizedTests {
 
     @Test
     public void testParameters() {
-
         assertThat((int)alpha, equalTo(code));
     }
 }

--- a/src/library/src/test/java/net/aichler/jupiter/api/StreamPairTest.java
+++ b/src/library/src/test/java/net/aichler/jupiter/api/StreamPairTest.java
@@ -18,16 +18,13 @@
  */
 package net.aichler.jupiter.api;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.PrintStream;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -35,30 +32,28 @@ import static org.mockito.Mockito.mock;
  */
 public class StreamPairTest {
 
-    @Rule
-    public final ExpectedException thrownException = ExpectedException.none();
-
     @Test
     public void shouldThrowExceptionIfOutIsNull() {
+        Exception thrownException = assertThrows(
+            NullPointerException.class,
+            () -> new StreamPair(null, mock(PrintStream.class))
+        );
 
-        thrownException.expect(NullPointerException.class);
-        thrownException.expectMessage(startsWith("Output stream "));
-
-        new StreamPair(null, mock(PrintStream.class));
+        assertThat(thrownException.getMessage(), startsWith("Output stream "));
     }
 
     @Test
     public void shouldThrowExceptionIfErrIsNull() {
+        Exception thrownException = assertThrows(
+            NullPointerException.class,
+            () ->  new StreamPair(mock(PrintStream.class), null)
+        );
 
-        thrownException.expect(NullPointerException.class);
-        thrownException.expectMessage(startsWith("Error stream "));
-
-        new StreamPair(mock(PrintStream.class), null);
+        assertThat(thrownException.getMessage(), startsWith("Error stream "));
     }
 
     @Test
     public void shouldGetTypeOut() {
-
         PrintStream out = mock(PrintStream.class);
         PrintStream err = mock(PrintStream.class);
 
@@ -69,7 +64,6 @@ public class StreamPairTest {
 
     @Test
     public void shouldGetTypeErr() {
-
         PrintStream out = mock(PrintStream.class);
         PrintStream err = mock(PrintStream.class);
 

--- a/src/library/src/test/java/net/aichler/jupiter/internal/ColorTest.java
+++ b/src/library/src/test/java/net/aichler/jupiter/internal/ColorTest.java
@@ -21,7 +21,7 @@ package net.aichler.jupiter.internal;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Michael Aichler

--- a/src/library/src/test/java/net/aichler/jupiter/internal/event/TaskNameTest.java
+++ b/src/library/src/test/java/net/aichler/jupiter/internal/event/TaskNameTest.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Michael Aichler

--- a/src/library/src/test/java/net/aichler/jupiter/internal/filter/GlobFilterTest.java
+++ b/src/library/src/test/java/net/aichler/jupiter/internal/filter/GlobFilterTest.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Michael Aichler

--- a/src/library/src/test/java/net/aichler/jupiter/internal/filter/TestFilterTest.java
+++ b/src/library/src/test/java/net/aichler/jupiter/internal/filter/TestFilterTest.java
@@ -28,7 +28,7 @@ import java.util.HashSet;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Michael Aichler

--- a/src/library/src/test/java/net/aichler/jupiter/internal/listeners/CapturedOutputStreamTest.java
+++ b/src/library/src/test/java/net/aichler/jupiter/internal/listeners/CapturedOutputStreamTest.java
@@ -25,7 +25,7 @@ import java.io.PrintStream;
 
 import static net.aichler.jupiter.internal.listeners.OutputCapturingTestListener.CapturedOutputStream;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Michael Aichler

--- a/src/library/src/test/java/net/aichler/jupiter/internal/listeners/FlatPrintingTestListenerFormatterTest.java
+++ b/src/library/src/test/java/net/aichler/jupiter/internal/listeners/FlatPrintingTestListenerFormatterTest.java
@@ -14,7 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test output formatting of test identifiers.

--- a/src/library/src/test/java/net/aichler/jupiter/internal/options/OptionsParserTest.java
+++ b/src/library/src/test/java/net/aichler/jupiter/internal/options/OptionsParserTest.java
@@ -3,7 +3,7 @@ package net.aichler.jupiter.internal.options;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class OptionsParserTest {
 

--- a/src/library/src/test/java/net/aichler/jupiter/tickets/n0001/Ticket0001Test.java
+++ b/src/library/src/test/java/net/aichler/jupiter/tickets/n0001/Ticket0001Test.java
@@ -8,7 +8,7 @@ import sbt.testing.Status;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Ticket0001Test {
 

--- a/src/library/src/test/java/net/aichler/jupiter/tickets/n0003/Ticket0003Test.java
+++ b/src/library/src/test/java/net/aichler/jupiter/tickets/n0003/Ticket0003Test.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Ticket0003Test {
 

--- a/src/plugin/src/main/scala/net/aichler/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/net/aichler/jupiter/sbt/JupiterPlugin.scala
@@ -29,7 +29,7 @@ import sbt.AutoPlugin
 import sbt.Def
 import sbt._
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 object Import {
 
@@ -109,7 +109,7 @@ object JupiterPlugin extends AutoPlugin {
       .withRuntimeClassPath(classpath)
       .build()
 
-    val discoveredTests = collector.collectTests().getDiscoveredTests.toList.map(toTestDefinition)
+    val discoveredTests = collector.collectTests().getDiscoveredTests.asScala.map(toTestDefinition)
     if (discoveredTests.nonEmpty) {
       if (!hasRuntimeLibrary(classpath)) {
         throw new RuntimeException(

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -1,15 +1,12 @@
 import sbt.Keys.libraryDependencies
 import net.aichler.jupiter.sbt.Import.JupiterKeys._
 
-
-//logBuffered in Test := false
-
 lazy val junit = (project in file("src/junit"))
   .enablePlugins(JvmPlugin)
   .settings(
     libraryDependencies ++= Seq(
       "com.novocode" % "junit-interface" % "0.11" % "test",
-      "junit" % "junit" % "4.12" % "test"
+      "junit" % "junit" % "4.13.2" % "test"
     ),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")
   )

--- a/test-project/project/build.properties
+++ b/test-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.0

--- a/test-project/project/build.properties
+++ b/test-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=1.8.3

--- a/test-project/project/plugins.sbt
+++ b/test-project/project/plugins.sbt
@@ -1,5 +1,5 @@
 lazy val pluginVersion = IO.readLines(file("../version.sbt"))
-  .filter(_.startsWith("version in ThisBuild"))
+  .filter(_.startsWith("ThisBuild / version"))
   .map(line => line.substring(line.indexOf('"')+1, line.lastIndexOf('"')))
   .head
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.2-SNAPSHOT"
+ThisBuild / version := "0.12.0-SNAPSHOT"


### PR DESCRIPTION
- bump to 0.12.0-SNAPSHOT
- migrate SBT to 1.9.0, drop support for SBT 0.13 / 1.0.0
- bump JUnit / JUnit 4 / Hamcrest / Mockito
- bump Scala to 2.12.18, remove cross scala compiling
- set minimum JDK version to 8, thus source / target to 1.8
- add encoding / xlint settings 

Compilation was tested with JDK 8, JDK 11, JDK 17. 

I didn't test whether the release plugin / sonatype plugin still works, as I'm not familiar with it.