### PR TITLE
Upgrade to support Junit 5.9.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,9 @@ import xerial.sbt.Sonatype.GitHubHosting
  */
 
 val Versions = new {
-  val junitJupiter = "5.9.1"
-  val junitPlatform = "1.9.1"
-  val junitVintage = "5.9.1"
+  val junitJupiter = "5.9.3"
+  val junitPlatform = "1.9.3"
+  val junitVintage = "5.9.3"
   val testInterface = "1.0"
 }
 


### PR DESCRIPTION
To fix https://github.com/sbt/sbt-jupiter-interface/issues/60, upgrade to support Junit 5.9.3