### PR TITLE
Refactor version strings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,14 +17,7 @@
  * limitations under the License.
  */
 
-Global / onChangedBuildSource := ReloadOnSourceChanges
-
-val Versions = new {
-  val junitJupiter = "5.9.3"
-  val junitPlatform = "1.9.1"
-  val junitVintage = "5.9.1"
-  val testInterface = "1.0"
-}
+import Dependencies.*
 
 ThisBuild / organization := "com.github.sbt.junit"
 ThisBuild / scalaVersion := "2.12.19"
@@ -37,17 +30,15 @@ lazy val library = (project in file("src/library"))
     (compile / javacOptions) ++= Seq("-source", "1.8", "-target", "1.8"),
     (doc / javacOptions) := Seq("-source", "1.8"),
     libraryDependencies ++= Seq(
-      "org.junit.platform" % "junit-platform-launcher" % Versions.junitPlatform,
-      "org.junit.jupiter" % "junit-jupiter-engine" % Versions.junitJupiter,
-      "org.scala-sbt" % "test-interface" % Versions.testInterface
-    ),
-    libraryDependencies ++= Seq(
-      "org.junit.jupiter" % "junit-jupiter-params" % Versions.junitJupiter % Test,
-      "org.junit.vintage" % "junit-vintage-engine" % Versions.junitVintage % Test,
-      "org.hamcrest" % "hamcrest-library" % "1.3" % Test,
-      "org.mockito" % "mockito-core" % "2.23.4" % Test,
-      "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-      "junit" % "junit" % "4.13.2" % Test,
+      junitPlatformLauncher,
+      junitJupiterEngine,
+      testInterface,
+      junitJupiterParams % Test,
+      junitVintageEngine % Test,
+      hamcrestLibrary % Test,
+      mockitoCore % Test,
+      junit4Interface % Test,
+      junit4 % Test,
     ),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     bspEnabled := false,
@@ -63,8 +54,8 @@ lazy val plugin = (project in file("src/plugin"))
     scriptedBufferLog := false,
     scriptedLaunchOpts ++= Seq(
       s"-Dproject.version=${version.value}",
-      s"-Djunit.jupiter.version=${Versions.junitJupiter}",
-      s"-Djunit.platform.version=${Versions.junitPlatform}"
+      s"-Djunit.jupiter.version=${junitJupiterVer}",
+      s"-Djunit.platform.version=${junitPlatformVer}"
     ),
     scriptedDependencies := {
       val () = publishLocal.value
@@ -93,14 +84,14 @@ def generateVersionFile = Def.task {
   val version = (library / Keys.version).value
   val file = (Compile / resourceManaged).value / "jupiter-interface.properties"
   val content = s"version=$version\n" +
-    s"junit.platform.version=${Versions.junitPlatform}\n" +
-    s"junit.jupiter.version=${Versions.junitJupiter}\n" +
-    s"junit.vintage.version=${Versions.junitVintage}\n"
+    s"junit.platform.version=${junitPlatformVer}\n" +
+    s"junit.jupiter.version=${junitJupiterVer}\n" +
+    s"junit.vintage.version=${junitVintageVer}\n"
   IO.write(file, content)
   Seq(file)
 }
 
-ThisBuild / homepage := Some(url("https://github.com/maichler/sbt-jupiter-interface"))
+ThisBuild / homepage := Some(url("https://github.com/sbt/sbt-jupiter-interface"))
 ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 ThisBuild / developers := List(
   Developer(id = "maichler", name = "Michael Aichler", email = "maichler@gmail.com", url = url("https://github.com/maichler"))
@@ -129,3 +120,4 @@ ThisBuild / githubWorkflowPublish := Seq(
   )
 )
 ThisBuild / sonatypeProfileName := "com.github.sbt"
+Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,20 @@
+import sbt.*
+
+object Dependencies {
+  val junitJupiterVer = "5.9.3"
+  // based on https://github.com/junit-team/junit5/releases/tag/r5.10.3 etc
+  // The platform version seems to be "1." of the corresponding JUnit 5.x version.
+  def junitPlatformVer = junitJupiterVer.replaceFirst("""^5\.""", "1.")
+  def junitVintageVer = junitJupiterVer
+  val testInterfaceVer = "1.0"
+
+  val junitPlatformLauncher = "org.junit.platform" % "junit-platform-launcher" % junitPlatformVer
+  val junitJupiterEngine = "org.junit.jupiter" % "junit-jupiter-engine" % junitJupiterVer
+  val testInterface = "org.scala-sbt" % "test-interface" % testInterfaceVer
+  val junitJupiterParams = "org.junit.jupiter" % "junit-jupiter-params" % junitJupiterVer
+  val junitVintageEngine = "org.junit.vintage" % "junit-vintage-engine" % junitVintageVer
+  val hamcrestLibrary = "org.hamcrest" % "hamcrest-library" % "1.3"
+  val mockitoCore = "org.mockito" % "mockito-core" % "2.23.4"
+  val junit4Interface = "com.github.sbt" % "junit-interface" % "0.13.3"
+  val junit4 = "junit" % "junit" % "4.13.2"
+}


### PR DESCRIPTION
To make sure that Scala Steward etc will atomically change the JUnit module versions this refactors the version strings into functions such that the platform version and the vintage version is calculated off of the jupiter version.