### PR TITLE
Show the `displayName` of dynamic tests in the sbt output and in the xml test reports

### DIFF
--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -350,7 +350,7 @@ public class Configuration {
         name =
             VINTAGE_ENGINE.equals(testEngine)
                 ? toVintageName(identifier, lastSegment)
-                : toName(lastSegment);
+                : toName(identifier, lastSegment);
       }
 
       return name;
@@ -359,7 +359,7 @@ public class Configuration {
     /*
      * Formats a test segment from junit-jupiter.
      */
-    private String toName(Segment segment) {
+    private String toName(TestIdentifier identifier, Segment segment) {
 
       String name;
 
@@ -377,7 +377,7 @@ public class Configuration {
           name = colorTheme.testFactory().format("#" + segment.getValue());
           break;
         case "dynamic-test":
-          name = colorTheme.dynamicTest().format(":" + segment.getValue());
+          name = colorTheme.dynamicTest().format(":" + identifier.getDisplayName());
           break;
         case "test-template":
           name = colorTheme.testTemplate().format("#" + segment.getValue());

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/event/TaskName.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/event/TaskName.java
@@ -101,7 +101,7 @@ class TaskName {
 
       MethodSource methodSource = (MethodSource) testSource;
       result.nestedSuiteId = nestedSuiteId(testSuite, methodSource.getClassName());
-      result.invocation = invocation(UniqueId.parse(identifier.getUniqueId()));
+      result.invocation = invocation(identifier, UniqueId.parse(identifier.getUniqueId()));
       result.testName =
           testName(methodSource.getMethodName(), methodSource.getMethodParameterTypes());
     }
@@ -159,7 +159,7 @@ class TaskName {
    * @param id The unique test identifier.
    * @return A string representation of the current invocation (might be {@code null}).
    */
-  static String invocation(UniqueId id) {
+  static String invocation(TestIdentifier identifier, UniqueId id) {
 
     List<UniqueId.Segment> segments = id.getSegments();
 
@@ -169,6 +169,7 @@ class TaskName {
 
       switch (last.getType()) {
         case "dynamic-test":
+          return identifier.getDisplayName();
         case "test-template-invocation":
           return last.getValue().replace("#", "");
       }

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/DispatcherSampleTests.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/DispatcherSampleTests.java
@@ -20,13 +20,14 @@ package com.github.sbt.junit.jupiter.internal.event;
 
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -45,7 +46,11 @@ class DispatcherSampleTests {
 
     @TestFactory
     Collection<DynamicTest> test() {
-      return Collections.singletonList(dynamicTest("1st dynamic test", () -> {}));
+      final Executable dummy = () -> {};
+      return Arrays.asList(
+          dynamicTest("1st dynamic test", dummy),
+          dynamicTest("2nd dynamic test", dummy),
+          dynamicTest("3rd dynamic test", dummy));
     }
   }
 

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/DispatcherTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/DispatcherTest.java
@@ -32,6 +32,7 @@ import com.github.sbt.junit.jupiter.internal.event.DispatcherSampleTests.Multipl
 import com.github.sbt.junit.jupiter.internal.event.DispatcherSampleTests.NestedTests;
 import com.github.sbt.junit.jupiter.internal.event.DispatcherSampleTests.ParameterizedTests;
 import com.github.sbt.junit.jupiter.internal.event.DispatcherSampleTests.SingleParamTests;
+import java.util.Arrays;
 import java.util.List;
 import junit.TestRunner;
 import org.hamcrest.FeatureMatcher;
@@ -121,12 +122,16 @@ public class DispatcherTest {
     List<Event> result = testRunner.eventHandler().byStatus(Status.Success);
 
     String suiteName = ".event.DispatcherSampleTests$DynamicTests";
-    String testName = "test():1";
+    List<String> testNames =
+        Arrays.asList(
+            "test():1st dynamic test", "test():2nd dynamic test", "test():3rd dynamic test");
 
-    assertThat(result, hasSize(1));
+    assertThat(result, hasSize(3));
     assertThat(result, hasItem(fullyQualifiedName(endsWith(suiteName))));
     assertThat(result, hasItem(selector(instanceOf(TestSelector.class))));
-    assertThat(result, hasItem(selector(testName(equalTo(testName)))));
+    for (String testName : testNames) {
+      assertThat(result, hasItem(selector(testName(equalTo(testName)))));
+    }
   }
 
   @Test

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/TaskNameTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/TaskNameTest.java
@@ -24,7 +24,10 @@ import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.runner.RunWith;
 
 /** @author Michael Aichler */
@@ -98,9 +101,11 @@ public class TaskNameTest {
     public void shouldFindDynamicTest() {
 
       UniqueId id = UniqueId.root("method", "someTestMethod").append("dynamic-test", "#1");
+      TestDescriptor descriptor = new DummyTestDescriptor(id, "myDynamicTest");
+      TestIdentifier identifier = TestIdentifier.from(descriptor);
 
-      String result = TaskName.invocation(id);
-      assertThat(result, equalTo("1"));
+      String result = TaskName.invocation(identifier, id);
+      assertThat(result, equalTo("myDynamicTest"));
     }
 
     @Test
@@ -108,8 +113,10 @@ public class TaskNameTest {
 
       UniqueId id =
           UniqueId.root("method", "someTestMethod").append("test-template-invocation", "#1");
+      TestDescriptor descriptor = new DummyTestDescriptor(id, "myTestTemplateInvocation");
+      TestIdentifier identifier = TestIdentifier.from(descriptor);
 
-      String result = TaskName.invocation(id);
+      String result = TaskName.invocation(identifier, id);
       assertThat(result, equalTo("1"));
     }
 
@@ -117,9 +124,22 @@ public class TaskNameTest {
     public void shouldReturnNullOtherwise() {
 
       UniqueId id = UniqueId.root("method", "someTestMethod");
+      TestDescriptor descriptor = new DummyTestDescriptor(id, "someTestMethod");
+      TestIdentifier identifier = TestIdentifier.from(descriptor);
 
-      String result = TaskName.invocation(id);
+      String result = TaskName.invocation(identifier, id);
       assertThat(result, nullValue());
+    }
+  }
+
+  private static class DummyTestDescriptor extends AbstractTestDescriptor {
+    protected DummyTestDescriptor(UniqueId uniqueId, String displayName) {
+      super(uniqueId, displayName);
+    }
+
+    @Override
+    public Type getType() {
+      return Type.CONTAINER_AND_TEST;
     }
   }
 }


### PR DESCRIPTION
Adresses https://github.com/sbt/sbt-jupiter-interface/issues/21#issuecomment-2273255522 specifically. This is not a comprehensive solution for `@DisplayName` support, although it could serve as a starting idea.

- The displayName of dynamic tests is never null or blank.
- https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/DynamicTest.html#dynamicTest(java.lang.String,org.junit.jupiter.api.function.Executable)

Here are some outputs of the `publishLocal` plugin in action:
1. `--display-mode=tree` stays unchanged
```
[info] JUnit Jupiter
[info]   ScalaBundleSortingTest
[info]     bundleSortingTests()
[info]       + ScalaBspBundle
[info]       + ScalaCodeInsightBundle
[info]       + ScalaCompileServerBundle
[info]       + CompilerIntegrationBundle
[info]       + ScalaJpsBundle
[info]       + ScalaCompileServerSharedBundle
[info]       + ScalaConversionBundle
[info]       + DebuggerBundle
[info]       + ScalaReplBundle
[info]       + ScalaDevkitBundle
[info]       + ScalaGradleBundle
[info]       + ScalaIntellilangBundle
[info]       + ScalaJavaDecompilerBundle
[info]       + ScalaI18nBundle
[info]       + SbtApiBundle
[info]       + SbtBundle
[info]       + ScalaBundle
[info]       + ScalaDirectiveBundle
[info]       + ScalaEditorBundle
[info]       + ScalaInspectionBundle
[info]       + ScalaMetaBundle
[info]       + ScalaOptionsBundle
[info]       + ScalaStructureViewBundle
[info]       + TestingSupportBundle
[info]       + ScalaWorksheetBundle
[info] Test run finished: 0 failed, 0 ignored, 25 total, 8.911s
```

2. `--display-mode=flat` now shows the `displayName` of the dynamic test instead of the test index
```
[info] Test run started (JUnit Jupiter)
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaBspBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaCodeInsightBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaCompileServerBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():CompilerIntegrationBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaJpsBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaCompileServerSharedBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaConversionBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():DebuggerBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaReplBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaDevkitBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaGradleBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaIntellilangBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaJavaDecompilerBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaI18nBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():SbtApiBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():SbtBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaDirectiveBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaEditorBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaInspectionBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaMetaBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaOptionsBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaStructureViewBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():TestingSupportBundle started
[info] Test org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest#bundleSortingTests():ScalaWorksheetBundle started
[info] Test run finished: 0 failed, 0 ignored, 25 total, 8.989s

```

3. XML test report output of the same test:
```xml
<testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaBspBundle" time="0.14">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaCodeInsightBundle" time="0.119">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaCompileServerBundle" time="0.022">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():CompilerIntegrationBundle" time="0.09">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaJpsBundle" time="0.054">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaCompileServerSharedBundle" time="0.022">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaConversionBundle" time="0.033">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():DebuggerBundle" time="0.066">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaReplBundle" time="0.013">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaDevkitBundle" time="0.007">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaGradleBundle" time="0.003">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaIntellilangBundle" time="0.012">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaJavaDecompilerBundle" time="0.003">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaI18nBundle" time="0.009">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():SbtApiBundle" time="0.018">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():SbtBundle" time="0.129">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaBundle" time="1.66">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaDirectiveBundle" time="1.307">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaEditorBundle" time="1.282">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaInspectionBundle" time="1.285">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaMetaBundle" time="1.278">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaOptionsBundle" time="1.287">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaStructureViewBundle" time="0.012">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():TestingSupportBundle" time="0.054">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.internal.bundle.ScalaBundleSortingTest" name="bundleSortingTests():ScalaWorksheetBundle" time="0.056">
                      
                    </testcase>
```