### PR TITLE
Redefine `definedTests` in terms of the task itself

### DIFF
--- a/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
@@ -80,13 +80,7 @@ object JupiterPlugin extends AutoPlugin {
    * By default this is applied to the Test configuration only.
    */
   def scopedSettings: Seq[Def.Setting[_]] = Seq(
-    definedTests := Def.taskDyn {
-      val otherTests = definedTests.value
-      Def.task {
-        val jupiterTests = collectTests.value
-        otherTests ++ jupiterTests
-      }
-    }.value
+    definedTests ++= collectTests.value
   )
 
   /*
@@ -100,8 +94,7 @@ object JupiterPlugin extends AutoPlugin {
   /*
    * Collects available tests through JUnit Jupiter's discovery mechanism.
    */
-  private def collectTests: Def.Initialize[Task[Seq[TestDefinition]]] = Def.task {
-
+  private def collectTests = Def.task[Seq[TestDefinition]] {
     val classes = classDirectory.value
     val classpath = dependencyClasspath.value.map(_.data.toURI.toURL).toArray :+ classes.toURI.toURL
 
@@ -122,7 +115,7 @@ object JupiterPlugin extends AutoPlugin {
     }
 
     discoveredTests
-  }
+  }.dependsOn(compile).triggeredBy(compile)
 
   /*
    * Checks whether this plugins runtime library is on the given classpath.

--- a/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
@@ -115,7 +115,7 @@ object JupiterPlugin extends AutoPlugin {
     }
 
     discoveredTests
-  }.dependsOn(compile).triggeredBy(compile)
+  }.dependsOn(compile)
 
   /*
    * Checks whether this plugins runtime library is on the given classpath.

--- a/src/plugin/src/sbt-test/interop/reports-missing-runtime/build.sbt
+++ b/src/plugin/src/sbt-test/interop/reports-missing-runtime/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
 TaskKey[Unit]("checkDefinedTestsThrowsException") := {
   (Test / definedTests).result.value match {
     case Inc(cause:Incomplete) =>
-      val actualMessage = cause.directCause.map(c => c.getMessage).getOrElse("")
+      val actualMessage = cause.causes.headOption.flatMap(_.directCause).map(_.getMessage).getOrElse("")
       val expectedMessage = "Found at least one JUnit 5 test"
       assert(actualMessage.startsWith(expectedMessage),
         s"Expected an exception containing a message starting with `$expectedMessage` (actual: `$actualMessage`)")

--- a/src/plugin/src/sbt-test/interop/reports-missing-runtime/build.sbt
+++ b/src/plugin/src/sbt-test/interop/reports-missing-runtime/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
 TaskKey[Unit]("checkDefinedTestsThrowsException") := {
   (Test / definedTests).result.value match {
     case Inc(cause:Incomplete) =>
-      val actualMessage = cause.causes.headOption.flatMap(_.directCause).map(_.getMessage).getOrElse("")
+      val actualMessage = cause.causes.flatMap(_.causes).headOption.flatMap(_.directCause).map(_.getMessage).getOrElse("")
       val expectedMessage = "Found at least one JUnit 5 test"
       assert(actualMessage.startsWith(expectedMessage),
         s"Expected an exception containing a message starting with `$expectedMessage` (actual: `$actualMessage`)")


### PR DESCRIPTION
Redefine `definedTests` in terms of the task itself to work correctly with other plugins which may redefine the task, instead of hardcoding it to `Defaults.detectTests`.