### PR TITLE
Fixes sbt#121: Suite task naming no longer crashes; or mangles vintage test names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ lazy val library = (project in file("src/library"))
       testInterface,
       junitJupiterParams % Test,
       junitVintageEngine % Test,
+      junitPlatformSuite % Test,
       hamcrestLibrary % Test,
       mockitoCore % Test,
       junit4Interface % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
   val testInterface = "org.scala-sbt" % "test-interface" % testInterfaceVer
   val junitJupiterParams = "org.junit.jupiter" % "junit-jupiter-params" % junitJupiterVer
   val junitVintageEngine = "org.junit.vintage" % "junit-vintage-engine" % junitVintageVer
+  val junitPlatformSuite = "org.junit.platform" % "junit-platform-suite" % junitPlatformVer
   val hamcrestLibrary = "org.hamcrest" % "hamcrest-library" % "3.0"
   val mockitoCore = "org.mockito" % "mockito-core" % "4.11.0"
   val junit4Interface = "com.github.sbt" % "junit-interface" % "0.13.3"

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -309,7 +309,12 @@ public class Configuration {
 
       final List<TestIdentifier> path = getPath(testPlan, identifier);
 
-      testEngine = UniqueId.parse(identifier.getUniqueId()).getEngineId().orElse(null);
+      // When run as part of a suite, the suite engine is the first segment, so look further
+      testEngine = UniqueId.parse(identifier.getUniqueId()).getSegments().stream()
+              .filter(segment -> segment.getType().equals("engine"))
+              .map(Segment::getValue)
+              .reduce((first, last) -> last)
+              .orElse(null);
 
       return path.stream()
           .skip(1)

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -310,7 +310,8 @@ public class Configuration {
       final List<TestIdentifier> path = getPath(testPlan, identifier);
 
       // When run as part of a suite, the suite engine is the first segment, so look further
-      testEngine = UniqueId.parse(identifier.getUniqueId()).getSegments().stream()
+      testEngine =
+          UniqueId.parse(identifier.getUniqueId()).getSegments().stream()
               .filter(segment -> segment.getType().equals("engine"))
               .map(Segment::getValue)
               .reduce((first, last) -> last)

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/event/TaskName.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/event/TaskName.java
@@ -101,7 +101,7 @@ class TaskName {
     if (testSource instanceof MethodSource) {
 
       MethodSource methodSource = (MethodSource) testSource;
-      result.nestedSuiteId = nestedSuiteId(testSuite, methodSource.getClassName());
+      result.nestedSuiteId = nestedSuiteId(removedJunit5SuiteName, methodSource.getClassName());
       result.invocation = invocation(identifier, UniqueId.parse(identifier.getUniqueId()));
       result.testName =
           testName(methodSource.getMethodName(), methodSource.getMethodParameterTypes());

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/listeners/FlatPrintingTestListenerFormatterTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/listeners/FlatPrintingTestListenerFormatterTest.java
@@ -40,7 +40,9 @@ public class FlatPrintingTestListenerFormatterTest {
       {"jupiter.samples.SimpleTests", "testWithParameter", "#{1}(org.junit.jupiter.api.TestInfo)"},
       {"jupiter.samples.VintageTests", "vintageTestMethod", "#{1}"},
       {"jupiter.samples.VintageEnclosedTests", "testMethod", "$NestedTest#{1}"},
-      {"jupiter.samples.VintageParameterizedTests", "testParameters", "#{1}[A-65]"}
+      {"jupiter.samples.VintageParameterizedTests", "testParameters", "#{1}[A-65]"},
+      {"jupiter.samples.SuiteTest", "firstTestMethod", "jupiter.samples.SimpleTests#{1}()"},
+      {"jupiter.samples.SuiteTest", "vintageTestMethod", "jupiter.samples.VintageTests#{1}"}
     };
 
     // @formatter:on

--- a/src/library/src/test/java/jupiter/samples/SuiteTest.java
+++ b/src/library/src/test/java/jupiter/samples/SuiteTest.java
@@ -1,0 +1,9 @@
+package jupiter.samples;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+/** Sample test methods for the junit-platform-suite-engine. */
+@Suite
+@SelectClasses({SimpleTests.class, VintageTests.class})
+public class SuiteTest { }

--- a/src/library/src/test/java/jupiter/samples/SuiteTest.java
+++ b/src/library/src/test/java/jupiter/samples/SuiteTest.java
@@ -6,4 +6,4 @@ import org.junit.platform.suite.api.Suite;
 /** Sample test methods for the junit-platform-suite-engine. */
 @Suite
 @SelectClasses({SimpleTests.class, VintageTests.class})
-public class SuiteTest { }
+public class SuiteTest {}


### PR DESCRIPTION
Fixes (and tests!) the two related issues in #121:
- In some situations `@Suite`s were used, a RuntimeException would be thrown when trying to report the test status: `Test class path.to.my.TestClass is not enclosed by path.to.my.SuiteClass`
- Junit 4 tests run as part of a suite had their names mangled
