### PR TITLE
Re-include class names in reported tests

### DIFF
--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -317,11 +317,7 @@ public class Configuration {
               .reduce((first, last) -> last)
               .orElse(null);
 
-      return path.stream()
-          .skip(1)
-          .map(this::toName)
-          .filter(Objects::nonNull)
-          .collect(Collectors.joining());
+      return path.stream().map(this::toName).filter(Objects::nonNull).collect(Collectors.joining());
     }
 
     private List<TestIdentifier> getPath(TestPlan testPlan, TestIdentifier identifier) {
@@ -390,7 +386,7 @@ public class Configuration {
           name = colorTheme.container().format(":" + segment.getValue());
           break;
         default:
-          name = segment.getValue();
+          name = null;
           break;
       }
 
@@ -436,7 +432,7 @@ public class Configuration {
         }
       }
 
-      return "/" + identifier.getDisplayName();
+      return null;
     }
 
     /*

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/listeners/FlatPrintingTestListenerFormatterTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/listeners/FlatPrintingTestListenerFormatterTest.java
@@ -29,18 +29,22 @@ public class FlatPrintingTestListenerFormatterTest {
     // @formatter:off
 
     return new Object[][] {
-      {"jupiter.samples.NestedTests", "testOfFirstNestedClass", "$First#{1}()"},
-      {"jupiter.samples.RepeatedTests", "repeatedTest", "#{1}():#1"},
+      {"jupiter.samples.NestedTests", "testOfFirstNestedClass", "{0}$First#{1}()"},
+      {"jupiter.samples.RepeatedTests", "repeatedTest", "{0}#{1}():#1"},
       {
         "jupiter.samples.RepeatedTests",
         "repeatedTestWithRepetitionInfo",
-        "#{1}(org.junit.jupiter.api.RepetitionInfo):#1"
+        "{0}#{1}(org.junit.jupiter.api.RepetitionInfo):#1"
       },
-      {"jupiter.samples.SimpleTests", "firstTestMethod", "#{1}()"},
-      {"jupiter.samples.SimpleTests", "testWithParameter", "#{1}(org.junit.jupiter.api.TestInfo)"},
-      {"jupiter.samples.VintageTests", "vintageTestMethod", "#{1}"},
-      {"jupiter.samples.VintageEnclosedTests", "testMethod", "$NestedTest#{1}"},
-      {"jupiter.samples.VintageParameterizedTests", "testParameters", "#{1}[A-65]"},
+      {"jupiter.samples.SimpleTests", "firstTestMethod", "{0}#{1}()"},
+      {
+        "jupiter.samples.SimpleTests",
+        "testWithParameter",
+        "{0}#{1}(org.junit.jupiter.api.TestInfo)"
+      },
+      {"jupiter.samples.VintageTests", "vintageTestMethod", "{0}#{1}"},
+      {"jupiter.samples.VintageEnclosedTests", "testMethod", "{0}$NestedTest#{1}"},
+      {"jupiter.samples.VintageParameterizedTests", "testParameters", "{0}#{1}[A-65]"},
       {"jupiter.samples.SuiteTest", "firstTestMethod", "jupiter.samples.SimpleTests#{1}()"},
       {"jupiter.samples.SuiteTest", "vintageTestMethod", "jupiter.samples.VintageTests#{1}"}
     };


### PR DESCRIPTION
This amends changes from #87, by removing the redundant ".skip(1)", and also reverts the changes done to the corresponding unit test.

Not sure what the expected behavior is for the toVintageName method, however the unit tests still pass and the output looks reasonable. @dji, would you mind checking this part, since it touches code that you added recently?

Fixes #125 