### PR TITLE
Fix handling for unknown JUnit segment types

### DIFF
--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -317,7 +317,7 @@ public class Configuration {
               .reduce((first, last) -> last)
               .orElse(null);
 
-      return path.stream().map(this::toName).filter(Objects::nonNull).collect(Collectors.joining());
+      return path.stream().map(this::toName).filter(Objects::nonNull).collect(Collectors.joining()).trim();
     }
 
     private List<TestIdentifier> getPath(TestPlan testPlan, TestIdentifier identifier) {
@@ -384,6 +384,9 @@ public class Configuration {
           break;
         case "test-template-invocation":
           name = colorTheme.container().format(":" + segment.getValue());
+          break;
+        case "suite": // Don't show junit5 suite as part of name
+          name = null;
           break;
         default:
           name = " " + segment.getValue();

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -325,7 +325,10 @@ public class Configuration {
       List<TestIdentifier> result = new ArrayList<>();
 
       do {
-        if (identifier.getSource().isPresent()) {
+        // If there is only one segment, do not filter it out even
+        // if the source is not present, since we need to show something
+        boolean isOnlySegment = (result.isEmpty() && !testPlan.getParent(identifier).isPresent())
+        if (identifier.getSource().isPresent() || isOnlySegment) {
           result.add(identifier);
         }
         identifier = testPlan.getParent(identifier).orElse(null);

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -385,6 +385,14 @@ public class Configuration {
         case "test-template-invocation":
           name = colorTheme.container().format(":" + segment.getValue());
           break;
+        // Kotest JUnit segment types
+        // https://github.com/kotest/kotest/blob/1af8657ead54c6c6fc6f2ff8f54388a68bc2e7f6/kotest-runner/kotest-runner-junit5/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt#L19-L29
+        case "spec": // Same as "class" above
+          name = colorClassName(segment.getValue(), colorTheme.container());
+          break;
+        case "test": // same as "method" above
+          name = colorTheme.testMethod().format("#" + segment.getValue());
+          break;
         default:
           name = null;
           break;

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -317,7 +317,11 @@ public class Configuration {
               .reduce((first, last) -> last)
               .orElse(null);
 
-      return path.stream().map(this::toName).filter(Objects::nonNull).collect(Collectors.joining()).trim();
+      return path.stream()
+          .map(this::toName)
+          .filter(Objects::nonNull)
+          .collect(Collectors.joining())
+          .trim();
     }
 
     private List<TestIdentifier> getPath(TestPlan testPlan, TestIdentifier identifier) {
@@ -327,7 +331,7 @@ public class Configuration {
       do {
         // If there is only one segment, do not filter it out even
         // if the source is not present, since we need to show something
-        boolean isOnlySegment = (result.isEmpty() && !testPlan.getParent(identifier).isPresent());
+        boolean isOnlySegment = (result.isEmpty());
         if (identifier.getSource().isPresent() || isOnlySegment) {
           result.add(identifier);
         }

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -327,7 +327,7 @@ public class Configuration {
       do {
         // If there is only one segment, do not filter it out even
         // if the source is not present, since we need to show something
-        boolean isOnlySegment = (result.isEmpty() && !testPlan.getParent(identifier).isPresent())
+        boolean isOnlySegment = (result.isEmpty() && !testPlan.getParent(identifier).isPresent());
         if (identifier.getSource().isPresent() || isOnlySegment) {
           result.add(identifier);
         }

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -385,16 +385,8 @@ public class Configuration {
         case "test-template-invocation":
           name = colorTheme.container().format(":" + segment.getValue());
           break;
-        // Kotest JUnit segment types
-        // https://github.com/kotest/kotest/blob/1af8657ead54c6c6fc6f2ff8f54388a68bc2e7f6/kotest-runner/kotest-runner-junit5/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt#L19-L29
-        case "spec": // Same as "class" above
-          name = colorClassName(segment.getValue(), colorTheme.container());
-          break;
-        case "test": // same as "method" above
-          name = colorTheme.testMethod().format("#" + segment.getValue());
-          break;
         default:
-          name = null;
+          name = " " + segment.getValue();
           break;
       }
 


### PR DESCRIPTION
Necessary to get sbt-jupiter-interface working with Kotlin's Kotest https://github.com/com-lihaoyi/mill/pull/4048

Rather than skipping the entire unknown segment types, we filter out `"suite"` segments explicitly (which appears to be what we actually need to do, e.g. in https://github.com/sbt/sbt-jupiter-interface/blob/43918484453f25ae8e852fae48d54d84be77e0fe/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/event/TaskName.java#L123) and leave unknown segment types as space-separated. We perform a final `.trim` on the generated string to ensure any leading spaces are removed, since when generating the strings for each segment we do not know whether it will be the leading segment or not

This appears to have been broken in https://github.com/sbt/sbt-jupiter-interface/pull/126/files, where returning `null` caused the entire test identifier to not render

It's not entirely clear to me why we filter out the `suite`  segments to begin with, but given that we do this seems like the better way to do it
