### PR TITLE
Upgrade javafmt to 0.9.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.25.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.8.0")
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.9.0")


### PR DESCRIPTION
- Replaces #149

Reason is 0.10.0 requires Java 11, but this repo still supports Java 8