### PR TITLE
🐛 fix: do not discover tests thare are not a class or a method (#142)

### DIFF
--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
@@ -26,10 +26,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.support.descriptor.ClassSource;
@@ -242,43 +239,48 @@ public class JupiterTestCollector {
 
       for (TestIdentifier identifier : testPlan.getChildren(rootIdentifier)) {
 
-        String fqn = fullyQualifiedName(identifier);
-        Selector selector = new SuiteSelector();
-
-        Item item = new Item();
-        item.fullyQualifiedClassName = fqn;
-        item.selectors.add(selector);
-        item.explicit = false;
-
-        result.discoveredTests.add(item);
+          fullyQualifiedName(identifier).ifPresent(fqn -> {
+    
+              Selector selector = new SuiteSelector();
+    
+              Item item = new Item();
+              item.fullyQualifiedClassName = fqn;
+              item.selectors.add(selector);
+              item.explicit = false;
+    
+              result.discoveredTests.add(item);
+          });
       }
     }
 
     return result;
   }
 
-  private String fullyQualifiedName(TestIdentifier testIdentifier) {
+  /**
+   * @return Optional.empty if the test is not a class or method
+   */
+  private Optional<String> fullyQualifiedName(TestIdentifier testIdentifier) {
 
     TestSource testSource = testIdentifier.getSource().orElse(null);
 
     if (testSource instanceof ClassSource) {
 
       ClassSource classSource = (ClassSource) testSource;
-      return classSource.getClassName();
+      return Optional.of(classSource.getClassName());
     }
 
     if (testSource instanceof MethodSource) {
 
       MethodSource methodSource = (MethodSource) testSource;
-      return methodSource.getClassName()
+      return Optional.of(methodSource.getClassName()
           + '#'
           + methodSource.getMethodName()
           + '('
           + methodSource.getMethodParameterTypes()
-          + ')';
+          + ')');
     }
 
-    return testIdentifier.getLegacyReportingName();
+    return Optional.empty();
   }
 
   /**

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
@@ -239,26 +239,25 @@ public class JupiterTestCollector {
 
       for (TestIdentifier identifier : testPlan.getChildren(rootIdentifier)) {
 
-          fullyQualifiedName(identifier).ifPresent(fqn -> {
-    
-              Selector selector = new SuiteSelector();
-    
-              Item item = new Item();
-              item.fullyQualifiedClassName = fqn;
-              item.selectors.add(selector);
-              item.explicit = false;
-    
-              result.discoveredTests.add(item);
-          });
+        fullyQualifiedName(identifier)
+            .ifPresent(
+                fqn -> {
+                  Selector selector = new SuiteSelector();
+
+                  Item item = new Item();
+                  item.fullyQualifiedClassName = fqn;
+                  item.selectors.add(selector);
+                  item.explicit = false;
+
+                  result.discoveredTests.add(item);
+                });
       }
     }
 
     return result;
   }
 
-  /**
-   * @return Optional.empty if the test is not a class or method
-   */
+  /** @return Optional.empty if the test is not a class or method */
   private Optional<String> fullyQualifiedName(TestIdentifier testIdentifier) {
 
     TestSource testSource = testIdentifier.getSource().orElse(null);
@@ -272,12 +271,13 @@ public class JupiterTestCollector {
     if (testSource instanceof MethodSource) {
 
       MethodSource methodSource = (MethodSource) testSource;
-      return Optional.of(methodSource.getClassName()
-          + '#'
-          + methodSource.getMethodName()
-          + '('
-          + methodSource.getMethodParameterTypes()
-          + ')');
+      return Optional.of(
+          methodSource.getClassName()
+              + '#'
+              + methodSource.getMethodName()
+              + '('
+              + methodSource.getMethodParameterTypes()
+              + ')');
     }
 
     return Optional.empty();

--- a/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/build.sbt
+++ b/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/build.sbt
@@ -1,0 +1,19 @@
+name := "test-project"
+libraryDependencies ++= Seq(
+  "com.github.sbt.junit" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
+  "io.cucumber" % "cucumber-junit-platform-engine" % "7.26.0" % Test,
+  "io.cucumber" %% "cucumber-scala" % "8.30.1" % Test,
+  "org.junit.platform" % "junit-platform-suite" % JupiterKeys.junitPlatformVersion.value % Test
+)
+
+val checkTestDefinitions = taskKey[Unit]("Tests that the test is discovered properly")
+
+checkTestDefinitions := {
+  val definitions = (Test / definedTests).value
+
+  assert(definitions.nonEmpty, "Did not find any test !")
+  assert(definitions.length == 1, "Found more than the one test (" + definitions.length + ")!")
+
+  streams.value.log.info("Test name = " + definitions.head.name)
+  assert(definitions.head.name == "cucumber.examples.scalacalculator.RunCukesTest", "Failed to discover/name the unit test!")
+}

--- a/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/project/plugins.sbt
+++ b/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % sys.props("project.version"))

--- a/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/main/scala/cucumber/examples/scalacalculator/RpnCalculator.scala
+++ b/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/main/scala/cucumber/examples/scalacalculator/RpnCalculator.scala
@@ -1,0 +1,34 @@
+package cucumber.examples.scalacalculator
+
+import scala.collection.mutable.Queue
+
+sealed trait Arg
+
+object Arg {
+  implicit def op(s: String): Op = Op(s)
+  implicit def value(v: Double): Val = Val(v)
+}
+
+case class Op(value: String) extends Arg
+case class Val(value: Double) extends Arg
+
+class RpnCalculator {
+  private val stack = Queue.empty[Double]
+
+  private def op(f: (Double, Double) => Double) =
+    stack += f(stack.dequeue(), stack.dequeue())
+
+  def push(arg: Arg): Unit = {
+    arg match {
+      case Op("+")    => op(_ + _)
+      case Op("-")    => op(_ - _)
+      case Op("*")    => op(_ * _)
+      case Op("/")    => op(_ / _)
+      case Val(value) => stack += value
+      case _          => ()
+    }
+    ()
+  }
+
+  def value: Double = stack.head
+}

--- a/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/test/resources/cucumber/examples/scalacalculator/basic_arithmetic.feature
+++ b/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/test/resources/cucumber/examples/scalacalculator/basic_arithmetic.feature
@@ -1,0 +1,7 @@
+@foo
+Feature: Basic Arithmetic
+
+  Scenario: Adding
+  # Try to change one of the values below to provoke a failure
+    When I add 4.0 and 5.0
+    Then the result is 9.0

--- a/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/test/resources/junit-platform.properties
+++ b/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+cucumber.plugin=pretty

--- a/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/test/scala/cucumber/examples/scalacalculator/RpnCalculatorStepDefinitions.scala
+++ b/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/test/scala/cucumber/examples/scalacalculator/RpnCalculatorStepDefinitions.scala
@@ -1,0 +1,23 @@
+package cucumber.examples.scalacalculator
+
+import io.cucumber.scala.{EN, ScalaDsl, Scenario}
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class RpnCalculatorStepDefinitions extends ScalaDsl with EN {
+
+  val calc = new RpnCalculator
+
+  When("""I add {double} and {double}""") { (arg1: Double, arg2: Double) =>
+    calc push arg1
+    calc push arg2
+    calc push "+"
+  }
+
+  Then("the result is {double}") { (expected: Double) =>
+    assertEquals(expected, calc.value, 0.001)
+  }
+
+  Before("not @foo") { (scenario: Scenario) =>
+    println(s"Runs before scenarios *not* tagged with @foo (${scenario.getId})")
+  }
+}

--- a/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/test/scala/cucumber/examples/scalacalculator/RunCukesTest.scala
+++ b/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/src/test/scala/cucumber/examples/scalacalculator/RunCukesTest.scala
@@ -1,0 +1,13 @@
+package cucumber.examples.scalacalculator
+
+import io.cucumber.junit.platform.engine.Constants
+import org.junit.platform.suite.api._
+
+@Suite
+@IncludeEngines(Array("cucumber"))
+@SelectPackages(Array("cucumber.examples.scalacalculator"))
+@ConfigurationParameter(
+  key = Constants.GLUE_PROPERTY_NAME,
+  value = "cucumber.examples.scalacalculator"
+)
+class RunCukesTest

--- a/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/test
+++ b/src/plugin/src/sbt-test/basic/ignore-non-class-method-tests/test
@@ -1,0 +1,6 @@
+# make sure we discover the unit tests appropriately
+> checkTestDefinitions
+# make sure the unit test passes
+> test
+# Debugging.
+> show definedTests


### PR DESCRIPTION
Aims to fix #142

The idea is to ignore tests that are not class or method-based. We could look to support them later if needed but for now they didn't work in the first place, so let's just ignore them.

I've confirmed on the example project of https://github.com/cucumber/cucumber-jvm-scala and the reproduction project of #142 that this change fixes the original issue reported in #142 .