### PR TITLE
Show the `displayName` of parameterized tests in the sbt output and in the xml test reports

### DIFF
--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/Configuration.java
@@ -400,7 +400,7 @@ public final class Configuration {
           name = colorTheme.testTemplate().format("#" + segment.getValue());
           break;
         case "test-template-invocation":
-          name = colorTheme.container().format(":" + segment.getValue());
+          name = colorTheme.container().format(":" + identifier.getDisplayName());
           break;
         case "suite": // Don't show junit5 suite as part of name
           name = null;

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/event/TaskName.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/event/TaskName.java
@@ -182,6 +182,7 @@ class TaskName {
   }
 
   /**
+   * @param identifier The test identifier.
    * @param id The unique test identifier.
    * @return A string representation of the current invocation (might be {@code null}).
    */
@@ -195,9 +196,8 @@ class TaskName {
 
       switch (last.getType()) {
         case "dynamic-test":
-          return identifier.getDisplayName();
         case "test-template-invocation":
-          return last.getValue().replace("#", "");
+          return identifier.getDisplayName();
       }
     }
 

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/DispatcherSampleTests.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/DispatcherSampleTests.java
@@ -61,6 +61,12 @@ class DispatcherSampleTests {
     void testValueSourceWithStrings(String value) {}
   }
 
+  static class CustomDisplayNameParameterizedTests {
+    @ParameterizedTest(name = "[param = {0}]")
+    @ValueSource(strings = {"foo", "bar", "baz"})
+    void testValueSourceWithStrings(String param) {}
+  }
+
   static class SingleParamTests {
 
     @Test

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/DispatcherTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/DispatcherTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 
+import com.github.sbt.junit.jupiter.internal.event.DispatcherSampleTests.CustomDisplayNameParameterizedTests;
 import com.github.sbt.junit.jupiter.internal.event.DispatcherSampleTests.DurationTests;
 import com.github.sbt.junit.jupiter.internal.event.DispatcherSampleTests.DynamicTests;
 import com.github.sbt.junit.jupiter.internal.event.DispatcherSampleTests.MultipleParamsTests;
@@ -104,12 +105,35 @@ public class DispatcherTest {
     List<Event> result = testRunner.eventHandler().byStatus(Status.Success);
 
     String suiteName = ".event.DispatcherSampleTests$ParameterizedTests";
-    String testName = "testValueSourceWithStrings(String):1";
+    String testName = "testValueSourceWithStrings(String):[1] \"foo\"";
 
     assertThat(result, hasSize(1));
     assertThat(result, hasItem(fullyQualifiedName(endsWith(suiteName))));
     assertThat(result, hasItem(selector(instanceOf(TestSelector.class))));
     assertThat(result, hasItem(selector(testName(equalTo(testName)))));
+  }
+
+  @Test
+  public void shouldReportParameterizedTestsWithCustomDisplayName() {
+
+    testRunner.withArgs("-v");
+    testRunner.execute(CustomDisplayNameParameterizedTests.class);
+
+    List<Event> result = testRunner.eventHandler().byStatus(Status.Success);
+
+    String suiteName = ".event.DispatcherSampleTests$CustomDisplayNameParameterizedTests";
+    List<String> testNames =
+        Arrays.asList(
+            "testValueSourceWithStrings(String):[param = \"foo\"]",
+            "testValueSourceWithStrings(String):[param = \"bar\"]",
+            "testValueSourceWithStrings(String):[param = \"baz\"]");
+
+    assertThat(result, hasSize(3));
+    assertThat(result, hasItem(fullyQualifiedName(endsWith(suiteName))));
+    assertThat(result, hasItem(selector(instanceOf(TestSelector.class))));
+    for (String testName : testNames) {
+      assertThat(result, hasItem(selector(testName(equalTo(testName)))));
+    }
   }
 
   @Test

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/TaskNameTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/event/TaskNameTest.java
@@ -117,7 +117,7 @@ public class TaskNameTest {
       TestIdentifier identifier = TestIdentifier.from(descriptor);
 
       String result = TaskName.invocation(identifier, id);
-      assertThat(result, equalTo("1"));
+      assertThat(result, equalTo("myTestTemplateInvocation"));
     }
 
     @Test

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/listeners/FlatPrintingTestListenerFormatterTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/listeners/FlatPrintingTestListenerFormatterTest.java
@@ -30,11 +30,11 @@ public class FlatPrintingTestListenerFormatterTest {
 
     return new Object[][] {
       {"jupiter.samples.NestedTests", "testOfFirstNestedClass", "{0}$First#{1}()"},
-      {"jupiter.samples.RepeatedTests", "repeatedTest", "{0}#{1}():#1"},
+      {"jupiter.samples.RepeatedTests", "repeatedTest", "{0}#{1}():repetition 1 of 10"},
       {
         "jupiter.samples.RepeatedTests",
         "repeatedTestWithRepetitionInfo",
-        "{0}#{1}(org.junit.jupiter.api.RepetitionInfo):#1"
+        "{0}#{1}(org.junit.jupiter.api.RepetitionInfo):repetition 1 of 5"
       },
       {"jupiter.samples.SimpleTests", "firstTestMethod", "{0}#{1}()"},
       {


### PR DESCRIPTION
Almost identical to #94.

The problem:
```
[info] Test run started (JUnit Jupiter)
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portFilePath() started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):#1 started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):#2 started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):#3 started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):#4 started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):#5 started
[info] Test run finished: 0 failed, 0 ignored, 6 total, 0.121s
```
Parameterized tests don't show their display name (set using `@ParameterizedTest(name = "custom name")`).
https://docs.junit.org/6.0.3/writing-tests/parameterized-classes-and-tests.html#display-names

This change _doesn't_ yet affect the `@DisplayName` support for paremeterized tests (test templates). That is also an option which we might add in the future. I.e. the name of the method (in this case `portNumber(int)` is also customizable with `@DisplayName(value = "some other custom name")`.

This change only affects the display names of "invocations", i.e. instantiations of Jupiter test templates (which includes parameterized tests, repeated tests and dynamic tests).

Here are the outputs (using `publishLocal` of this branch):

1. `--display-mode=tree` stays unchanged
```
[info] JUnit Jupiter
[info]   CompileServerPortTest
[info]     + portFilePath()
[info]     portNumber(int)
[info]       + port = 3200
[info]       + port = 6400
[info]       + port = 10501
[info]       + port = 50005
[info]       + port = 55055
[info] Test run finished: 0 failed, 0 ignored, 6 total, 0.122s
```
2. `--display-mode=flat` now shows the `displayName` of the parameterized test instead of the test index
```
[info] Test run started (JUnit Jupiter)
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portFilePath() started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):port = 3200 started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):port = 6400 started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):port = 10501 started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):port = 50005 started
[info] Test org.jetbrains.plugins.scala.compiler.CompileServerPortTest#portNumber(int):port = 55055 started
[info] Test run finished: 0 failed, 0 ignored, 6 total, 0.124s
```
3. XML test report output of the same test class
```
<testcase classname="org.jetbrains.plugins.scala.compiler.CompileServerPortTest" name="portFilePath()" time="0.022">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.compiler.CompileServerPortTest" name="portNumber(int):port = 3200" time="0.036">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.compiler.CompileServerPortTest" name="portNumber(int):port = 6400" time="0.003">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.compiler.CompileServerPortTest" name="portNumber(int):port = 10501" time="0.002">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.compiler.CompileServerPortTest" name="portNumber(int):port = 50005" time="0.002">
                      
                    </testcase><testcase classname="org.jetbrains.plugins.scala.compiler.CompileServerPortTest" name="portNumber(int):port = 55055" time="0.002">
                      
                    </testcase>
```