### PR TITLE
Configure the JUnit Platform launcher via JupiterLauncherConfig

### DIFF
--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfig.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfig.java
@@ -18,12 +18,30 @@
  */
 package com.github.sbt.junit.jupiter.api;
 
+import java.util.List;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.core.LauncherConfig;
+
 /**
  * Configures the Jupiter Test Discovery Launcher.
  *
- * <p>Each component toggles automatic registration of one of JUnit Platform's discoverable service
- * provider interfaces. The corresponding implementations need to be present on the classpath to be
- * registered automatically.
+ * <p>The first 5 components toggle automatic registration of one of JUnit Platform's discoverable
+ * service provider interfaces. The corresponding implementations need to be present on the
+ * classpath to be registered automatically.
+ *
+ * <p>The remaining 5 components let the caller register additional implementations explicitly by
+ * fully qualified class name. This is typically used in combination with the matching {@code
+ * *AutoRegistrationEnabled = false} flag, where the user wants to provide a hand-picked set of SPI
+ * implementations rather than rely on classpath auto-discovery (or where the runner runs in a
+ * separate JVM and instances cannot be transported across the JVM boundary). Each named class is
+ * loaded via the test classloader and instantiated through its {@code public} no-arg constructor at
+ * the moment a JUnit {@link LauncherConfig} is built. Classes that are missing, lack a {@code
+ * public} no-arg constructor, or do not implement the corresponding SPI interface cause a {@link
+ * RuntimeException} at that point.
  *
  * @param testEngineAutoRegistrationEnabled enable/disable auto registration of test engines. Test
  *     engines need to be present on the classpath to be registered automatically.
@@ -39,15 +57,110 @@ package com.github.sbt.junit.jupiter.api;
  * @param postDiscoveryFilterAutoRegistrationEnabled enable/disable auto registration of post
  *     discovery filters. Post discovery filters need to be present on the classpath to be
  *     registered automatically.
+ * @param testEngineClassNames fully qualified class names of additional {@link TestEngine}
+ *     implementations to register with the launcher. Each class is instantiated via its {@code
+ *     public} no-arg constructor.
+ * @param launcherSessionListenerClassNames fully qualified class names of additional {@link
+ *     LauncherSessionListener} implementations to register with the launcher. Each class is
+ *     instantiated via its {@code public} no-arg constructor.
+ * @param launcherDiscoveryListenerClassNames fully qualified class names of additional {@link
+ *     LauncherDiscoveryListener} implementations to register with the launcher. Each class is
+ *     instantiated via its {@code public} no-arg constructor.
+ * @param testExecutionListenerClassNames fully qualified class names of additional {@link
+ *     TestExecutionListener} implementations to register with the launcher. Each class is
+ *     instantiated via its {@code public} no-arg constructor.
+ * @param postDiscoveryFilterClassNames fully qualified class names of additional {@link
+ *     PostDiscoveryFilter} implementations to register with the launcher. Each class is
+ *     instantiated via its {@code public} no-arg constructor.
  */
 public record JupiterLauncherConfig(
     boolean testEngineAutoRegistrationEnabled,
     boolean launcherSessionListenerAutoRegistrationEnabled,
     boolean launcherDiscoveryListenerAutoRegistrationEnabled,
     boolean testExecutionListenerAutoRegistrationEnabled,
-    boolean postDiscoveryFilterAutoRegistrationEnabled) {
+    boolean postDiscoveryFilterAutoRegistrationEnabled,
+    List<String> testEngineClassNames,
+    List<String> launcherSessionListenerClassNames,
+    List<String> launcherDiscoveryListenerClassNames,
+    List<String> testExecutionListenerClassNames,
+    List<String> postDiscoveryFilterClassNames) {
+
+  /**
+   * Convenience constructor for the 5 boolean toggles, with all FQN lists empty. Equivalent to
+   * passing {@link List#of()} for each list component.
+   */
+  public JupiterLauncherConfig(
+      boolean testEngineAutoRegistrationEnabled,
+      boolean launcherSessionListenerAutoRegistrationEnabled,
+      boolean launcherDiscoveryListenerAutoRegistrationEnabled,
+      boolean testExecutionListenerAutoRegistrationEnabled,
+      boolean postDiscoveryFilterAutoRegistrationEnabled) {
+    this(
+        testEngineAutoRegistrationEnabled,
+        launcherSessionListenerAutoRegistrationEnabled,
+        launcherDiscoveryListenerAutoRegistrationEnabled,
+        testExecutionListenerAutoRegistrationEnabled,
+        postDiscoveryFilterAutoRegistrationEnabled,
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of());
+  }
 
   /** A configuration with auto registration enabled for all service provider interfaces. */
   public static final JupiterLauncherConfig DEFAULT =
       new JupiterLauncherConfig(true, true, true, true, true);
+
+  /**
+   * Builds a JUnit Platform {@link LauncherConfig} from this configuration. Each FQN in the 5 list
+   * components is loaded through the supplied {@code cl} and instantiated via its {@code public}
+   * no-arg constructor.
+   *
+   * @param cl class loader used to resolve the FQNs.
+   * @return a JUnit Platform launcher configuration.
+   * @throws RuntimeException if any FQN cannot be resolved, lacks a {@code public} no-arg
+   *     constructor, or does not implement the corresponding SPI interface.
+   */
+  public LauncherConfig toJUnitConfig(ClassLoader cl) {
+
+    final var builder =
+        LauncherConfig.builder()
+            .enableTestEngineAutoRegistration(testEngineAutoRegistrationEnabled)
+            .enableLauncherSessionListenerAutoRegistration(
+                launcherSessionListenerAutoRegistrationEnabled)
+            .enableLauncherDiscoveryListenerAutoRegistration(
+                launcherDiscoveryListenerAutoRegistrationEnabled)
+            .enableTestExecutionListenerAutoRegistration(
+                testExecutionListenerAutoRegistrationEnabled)
+            .enablePostDiscoveryFilterAutoRegistration(postDiscoveryFilterAutoRegistrationEnabled);
+
+    for (final var fqn : testEngineClassNames) {
+      builder.addTestEngines(newInstance(cl, fqn, TestEngine.class));
+    }
+    for (final var fqn : launcherSessionListenerClassNames) {
+      builder.addLauncherSessionListeners(newInstance(cl, fqn, LauncherSessionListener.class));
+    }
+    for (final var fqn : launcherDiscoveryListenerClassNames) {
+      builder.addLauncherDiscoveryListeners(newInstance(cl, fqn, LauncherDiscoveryListener.class));
+    }
+    for (final var fqn : testExecutionListenerClassNames) {
+      builder.addTestExecutionListeners(newInstance(cl, fqn, TestExecutionListener.class));
+    }
+    for (final var fqn : postDiscoveryFilterClassNames) {
+      builder.addPostDiscoveryFilters(newInstance(cl, fqn, PostDiscoveryFilter.class));
+    }
+
+    return builder.build();
+  }
+
+  private static <T> T newInstance(ClassLoader cl, String fqn, Class<T> iface) {
+    try {
+      final var clazz = Class.forName(fqn, true, cl);
+      final var instance = clazz.getConstructor().newInstance();
+      return iface.cast(instance);
+    } catch (ReflectiveOperationException | ClassCastException e) {
+      throw new RuntimeException("Failed to instantiate " + fqn + " as " + iface.getName(), e);
+    }
+  }
 }

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfig.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfig.java
@@ -85,32 +85,10 @@ public record JupiterLauncherConfig(
     List<String> testExecutionListenerClassNames,
     List<String> postDiscoveryFilterClassNames) {
 
-  /**
-   * Convenience constructor for the 5 boolean toggles, with all FQN lists empty. Equivalent to
-   * passing {@link List#of()} for each list component.
-   */
-  public JupiterLauncherConfig(
-      boolean testEngineAutoRegistrationEnabled,
-      boolean launcherSessionListenerAutoRegistrationEnabled,
-      boolean launcherDiscoveryListenerAutoRegistrationEnabled,
-      boolean testExecutionListenerAutoRegistrationEnabled,
-      boolean postDiscoveryFilterAutoRegistrationEnabled) {
-    this(
-        testEngineAutoRegistrationEnabled,
-        launcherSessionListenerAutoRegistrationEnabled,
-        launcherDiscoveryListenerAutoRegistrationEnabled,
-        testExecutionListenerAutoRegistrationEnabled,
-        postDiscoveryFilterAutoRegistrationEnabled,
-        List.of(),
-        List.of(),
-        List.of(),
-        List.of(),
-        List.of());
-  }
-
   /** A configuration with auto registration enabled for all service provider interfaces. */
   public static final JupiterLauncherConfig DEFAULT =
-      new JupiterLauncherConfig(true, true, true, true, true);
+      new JupiterLauncherConfig(
+          true, true, true, true, true, List.of(), List.of(), List.of(), List.of(), List.of());
 
   /**
    * Builds a JUnit Platform {@link LauncherConfig} from this configuration. Each FQN in the 5 list

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfig.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfig.java
@@ -19,6 +19,7 @@
 package com.github.sbt.junit.jupiter.api;
 
 import java.util.List;
+import java.util.function.IntFunction;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherSessionListener;
@@ -101,44 +102,39 @@ public record JupiterLauncherConfig(
    *     constructor, or does not implement the corresponding SPI interface.
    */
   public LauncherConfig toJUnitConfig(ClassLoader cl) {
-
-    final var builder =
-        LauncherConfig.builder()
-            .enableTestEngineAutoRegistration(testEngineAutoRegistrationEnabled)
-            .enableLauncherSessionListenerAutoRegistration(
-                launcherSessionListenerAutoRegistrationEnabled)
-            .enableLauncherDiscoveryListenerAutoRegistration(
-                launcherDiscoveryListenerAutoRegistrationEnabled)
-            .enableTestExecutionListenerAutoRegistration(
-                testExecutionListenerAutoRegistrationEnabled)
-            .enablePostDiscoveryFilterAutoRegistration(postDiscoveryFilterAutoRegistrationEnabled);
-
-    for (final var fqn : testEngineClassNames) {
-      builder.addTestEngines(newInstance(cl, fqn, TestEngine.class));
-    }
-    for (final var fqn : launcherSessionListenerClassNames) {
-      builder.addLauncherSessionListeners(newInstance(cl, fqn, LauncherSessionListener.class));
-    }
-    for (final var fqn : launcherDiscoveryListenerClassNames) {
-      builder.addLauncherDiscoveryListeners(newInstance(cl, fqn, LauncherDiscoveryListener.class));
-    }
-    for (final var fqn : testExecutionListenerClassNames) {
-      builder.addTestExecutionListeners(newInstance(cl, fqn, TestExecutionListener.class));
-    }
-    for (final var fqn : postDiscoveryFilterClassNames) {
-      builder.addPostDiscoveryFilters(newInstance(cl, fqn, PostDiscoveryFilter.class));
-    }
-
-    return builder.build();
+    return LauncherConfig.builder()
+        .enableTestEngineAutoRegistration(testEngineAutoRegistrationEnabled)
+        .enableLauncherSessionListenerAutoRegistration(
+            launcherSessionListenerAutoRegistrationEnabled)
+        .enableLauncherDiscoveryListenerAutoRegistration(
+            launcherDiscoveryListenerAutoRegistrationEnabled)
+        .enableTestExecutionListenerAutoRegistration(testExecutionListenerAutoRegistrationEnabled)
+        .enablePostDiscoveryFilterAutoRegistration(postDiscoveryFilterAutoRegistrationEnabled)
+        .addTestEngines(newInstances(cl, testEngineClassNames, TestEngine[]::new))
+        .addLauncherSessionListeners(
+            newInstances(cl, launcherSessionListenerClassNames, LauncherSessionListener[]::new))
+        .addLauncherDiscoveryListeners(
+            newInstances(cl, launcherDiscoveryListenerClassNames, LauncherDiscoveryListener[]::new))
+        .addTestExecutionListeners(
+            newInstances(cl, testExecutionListenerClassNames, TestExecutionListener[]::new))
+        .addPostDiscoveryFilters(
+            newInstances(cl, postDiscoveryFilterClassNames, PostDiscoveryFilter[]::new))
+        .build();
   }
 
-  private static <T> T newInstance(ClassLoader cl, String fqn, Class<T> iface) {
-    try {
-      final var clazz = Class.forName(fqn, true, cl);
-      final var instance = clazz.getConstructor().newInstance();
-      return iface.cast(instance);
-    } catch (ReflectiveOperationException | ClassCastException e) {
-      throw new RuntimeException("Failed to instantiate " + fqn + " as " + iface.getName(), e);
+  @SuppressWarnings("unchecked")
+  private static <T> T[] newInstances(
+      ClassLoader cl, List<String> fqns, IntFunction<T[]> arrayFactory) {
+    final var result = arrayFactory.apply(fqns.size());
+    final var iface = result.getClass().getComponentType();
+    for (var i = 0; i < fqns.size(); i++) {
+      final var fqn = fqns.get(i);
+      try {
+        result[i] = (T) Class.forName(fqn, true, cl).getConstructor().newInstance();
+      } catch (ReflectiveOperationException | ArrayStoreException | ClassCastException e) {
+        throw new RuntimeException("Failed to instantiate " + fqn + " as " + iface.getName(), e);
+      }
     }
+    return result;
   }
 }

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfig.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfig.java
@@ -1,0 +1,53 @@
+/*
+ * jupiter-interface
+ *
+ * Copyright (c) 2017, Michael Aichler.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.sbt.junit.jupiter.api;
+
+/**
+ * Configures the Jupiter Test Discovery Launcher.
+ *
+ * <p>Each component toggles automatic registration of one of JUnit Platform's discoverable service
+ * provider interfaces. The corresponding implementations need to be present on the classpath to be
+ * registered automatically.
+ *
+ * @param testEngineAutoRegistrationEnabled enable/disable auto registration of test engines. Test
+ *     engines need to be present on the classpath to be registered automatically.
+ * @param launcherSessionListenerAutoRegistrationEnabled enable/disable auto registration of
+ *     launcher session listeners. Launcher session listeners need to be present on the classpath to
+ *     be registered automatically.
+ * @param launcherDiscoveryListenerAutoRegistrationEnabled enable/disable auto registration of
+ *     launcher discovery listeners. Launcher discovery listeners need to be present on the
+ *     classpath to be registered automatically.
+ * @param testExecutionListenerAutoRegistrationEnabled enable/disable auto registration of test
+ *     execution listeners. Test execution listeners need to be present on the classpath to be
+ *     registered automatically.
+ * @param postDiscoveryFilterAutoRegistrationEnabled enable/disable auto registration of post
+ *     discovery filters. Post discovery filters need to be present on the classpath to be
+ *     registered automatically.
+ */
+public record JupiterLauncherConfig(
+    boolean testEngineAutoRegistrationEnabled,
+    boolean launcherSessionListenerAutoRegistrationEnabled,
+    boolean launcherDiscoveryListenerAutoRegistrationEnabled,
+    boolean testExecutionListenerAutoRegistrationEnabled,
+    boolean postDiscoveryFilterAutoRegistrationEnabled) {
+
+  /** A configuration with auto registration enabled for all service provider interfaces. */
+  public static final JupiterLauncherConfig DEFAULT =
+      new JupiterLauncherConfig(true, true, true, true, true);
+}

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
@@ -51,12 +51,7 @@ public class JupiterTestCollector {
   private final ClassLoader classLoader;
   private final URL[] runtimeClassPath;
   private final File classDirectory;
-
-  private final boolean testEngineAutoRegistrationEnabled;
-  private final boolean launcherSessionListenerAutoRegistrationEnabled;
-  private final boolean launcherDiscoveryListenerAutoRegistrationEnabled;
-  private final boolean testExecutionListenerAutoRegistrationEnabled;
-  private final boolean postDiscoveryFilterAutoRegistrationEnabled;
+  private final JupiterLauncherConfig launcherConfig;
 
   /**
    * Executes a JUnit Jupiter launcher discovery request.
@@ -173,6 +168,7 @@ public class JupiterTestCollector {
     private ClassLoader classLoader;
     private URL[] runtimeClassPath = new URL[0];
     private File classDirectory;
+    private JupiterLauncherConfig launcherConfig;
 
     private boolean testEngineAutoRegistrationEnabled = true;
     private boolean launcherSessionListenerAutoRegistrationEnabled = true;
@@ -218,12 +214,28 @@ public class JupiterTestCollector {
     }
 
     /**
+     * Configures the Jupiter Test Discovery Launcher.
+     *
+     * <p>When set, the value supplied here takes precedence over any of the deprecated per-flag
+     * setters on this builder.
+     *
+     * @param value the launcher configuration.
+     * @return This builder.
+     */
+    public Builder withLauncherConfig(JupiterLauncherConfig value) {
+      this.launcherConfig = value;
+      return this;
+    }
+
+    /**
      * Configures the Jupiter Test Discovery Launcher to enable/disable auto registration of test
      * engines. Test engines need to be present on the classpath to be registered automatically.
      *
      * @param value enable/disable auto registration
      * @return This builder.
+     * @deprecated Use {@link #withLauncherConfig(JupiterLauncherConfig)} instead.
      */
+    @Deprecated(since = "0.19.0", forRemoval = true)
     public Builder withTestEngineAutoRegistrationEnabled(boolean value) {
       this.testEngineAutoRegistrationEnabled = value;
       return this;
@@ -236,7 +248,9 @@ public class JupiterTestCollector {
      *
      * @param value enable/disable auto registration
      * @return This builder.
+     * @deprecated Use {@link #withLauncherConfig(JupiterLauncherConfig)} instead.
      */
+    @Deprecated(since = "0.19.0", forRemoval = true)
     public Builder withLauncherSessionListenerAutoRegistrationEnabled(boolean value) {
       this.launcherSessionListenerAutoRegistrationEnabled = value;
       return this;
@@ -249,7 +263,9 @@ public class JupiterTestCollector {
      *
      * @param value enable/disable auto registration
      * @return This builder.
+     * @deprecated Use {@link #withLauncherConfig(JupiterLauncherConfig)} instead.
      */
+    @Deprecated(since = "0.19.0", forRemoval = true)
     public Builder withLauncherDiscoveryListenerAutoRegistrationEnabled(boolean value) {
       this.launcherDiscoveryListenerAutoRegistrationEnabled = value;
       return this;
@@ -262,7 +278,9 @@ public class JupiterTestCollector {
      *
      * @param value enable/disable auto registration
      * @return This builder.
+     * @deprecated Use {@link #withLauncherConfig(JupiterLauncherConfig)} instead.
      */
+    @Deprecated(since = "0.19.0", forRemoval = true)
     public Builder withTestExecutionListenerAutoRegistrationEnabled(boolean value) {
       this.testExecutionListenerAutoRegistrationEnabled = value;
       return this;
@@ -275,7 +293,9 @@ public class JupiterTestCollector {
      *
      * @param value enable/disable auto registration
      * @return This builder.
+     * @deprecated Use {@link #withLauncherConfig(JupiterLauncherConfig)} instead.
      */
+    @Deprecated(since = "0.19.0", forRemoval = true)
     public Builder withPostDiscoveryFilterAutoRegistrationEnabled(boolean value) {
       this.postDiscoveryFilterAutoRegistrationEnabled = value;
       return this;
@@ -302,15 +322,15 @@ public class JupiterTestCollector {
     this.runtimeClassPath = builder.runtimeClassPath;
     this.classDirectory = builder.classDirectory;
     this.classLoader = builder.classLoader;
-    this.testEngineAutoRegistrationEnabled = builder.testEngineAutoRegistrationEnabled;
-    this.launcherSessionListenerAutoRegistrationEnabled =
-        builder.launcherSessionListenerAutoRegistrationEnabled;
-    this.launcherDiscoveryListenerAutoRegistrationEnabled =
-        builder.launcherDiscoveryListenerAutoRegistrationEnabled;
-    this.testExecutionListenerAutoRegistrationEnabled =
-        builder.testExecutionListenerAutoRegistrationEnabled;
-    this.postDiscoveryFilterAutoRegistrationEnabled =
-        builder.postDiscoveryFilterAutoRegistrationEnabled;
+    this.launcherConfig =
+        builder.launcherConfig != null
+            ? builder.launcherConfig
+            : new JupiterLauncherConfig(
+                builder.testEngineAutoRegistrationEnabled,
+                builder.launcherSessionListenerAutoRegistrationEnabled,
+                builder.launcherDiscoveryListenerAutoRegistrationEnabled,
+                builder.testExecutionListenerAutoRegistrationEnabled,
+                builder.postDiscoveryFilterAutoRegistrationEnabled);
   }
 
   /**
@@ -331,14 +351,15 @@ public class JupiterTestCollector {
 
     LauncherConfig config =
         LauncherConfig.builder()
-            .enableTestEngineAutoRegistration(testEngineAutoRegistrationEnabled)
+            .enableTestEngineAutoRegistration(launcherConfig.testEngineAutoRegistrationEnabled())
             .enableLauncherSessionListenerAutoRegistration(
-                launcherSessionListenerAutoRegistrationEnabled)
+                launcherConfig.launcherSessionListenerAutoRegistrationEnabled())
             .enableLauncherDiscoveryListenerAutoRegistration(
-                launcherDiscoveryListenerAutoRegistrationEnabled)
+                launcherConfig.launcherDiscoveryListenerAutoRegistrationEnabled())
             .enableTestExecutionListenerAutoRegistration(
-                testExecutionListenerAutoRegistrationEnabled)
-            .enablePostDiscoveryFilterAutoRegistration(postDiscoveryFilterAutoRegistrationEnabled)
+                launcherConfig.testExecutionListenerAutoRegistrationEnabled())
+            .enablePostDiscoveryFilterAutoRegistration(
+                launcherConfig.postDiscoveryFilterAutoRegistrationEnabled())
             .build();
 
     TestPlan testPlan = LauncherFactory.create(config).discover(request);

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
@@ -34,7 +34,6 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import sbt.testing.Fingerprint;
@@ -349,18 +348,7 @@ public class JupiterTestCollector {
             .selectors(selectDirectory(classDirectory))
             .build();
 
-    LauncherConfig config =
-        LauncherConfig.builder()
-            .enableTestEngineAutoRegistration(launcherConfig.testEngineAutoRegistrationEnabled())
-            .enableLauncherSessionListenerAutoRegistration(
-                launcherConfig.launcherSessionListenerAutoRegistrationEnabled())
-            .enableLauncherDiscoveryListenerAutoRegistration(
-                launcherConfig.launcherDiscoveryListenerAutoRegistrationEnabled())
-            .enableTestExecutionListenerAutoRegistration(
-                launcherConfig.testExecutionListenerAutoRegistrationEnabled())
-            .enablePostDiscoveryFilterAutoRegistration(
-                launcherConfig.postDiscoveryFilterAutoRegistrationEnabled())
-            .build();
+    final var config = launcherConfig.toJUnitConfig(Thread.currentThread().getContextClassLoader());
 
     TestPlan testPlan = LauncherFactory.create(config).discover(request);
 

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
@@ -329,7 +329,12 @@ public class JupiterTestCollector {
                 builder.launcherSessionListenerAutoRegistrationEnabled,
                 builder.launcherDiscoveryListenerAutoRegistrationEnabled,
                 builder.testExecutionListenerAutoRegistrationEnabled,
-                builder.postDiscoveryFilterAutoRegistrationEnabled);
+                builder.postDiscoveryFilterAutoRegistrationEnabled,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of());
   }
 
   /**

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/JupiterRunner.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/JupiterRunner.java
@@ -44,7 +44,6 @@ import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import sbt.testing.EventHandler;
@@ -177,19 +176,7 @@ public class JupiterRunner implements Runner {
         builder.selectors(testSelector(testSuiteName));
         builder.filters(testFilters(dispatcher));
 
-        final var config =
-            LauncherConfig.builder()
-                .enableTestEngineAutoRegistration(
-                    launcherConfig.testEngineAutoRegistrationEnabled())
-                .enableLauncherSessionListenerAutoRegistration(
-                    launcherConfig.launcherSessionListenerAutoRegistrationEnabled())
-                .enableLauncherDiscoveryListenerAutoRegistration(
-                    launcherConfig.launcherDiscoveryListenerAutoRegistrationEnabled())
-                .enableTestExecutionListenerAutoRegistration(
-                    launcherConfig.testExecutionListenerAutoRegistrationEnabled())
-                .enablePostDiscoveryFilterAutoRegistration(
-                    launcherConfig.postDiscoveryFilterAutoRegistrationEnabled())
-                .build();
+        final var config = launcherConfig.toJUnitConfig(testClassLoader);
         final Launcher launcher = LauncherFactory.create(config);
 
         launcher.registerTestExecutionListeners(dispatcher);

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/JupiterRunner.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/JupiterRunner.java
@@ -23,6 +23,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMetho
 import static org.junit.platform.launcher.TagFilter.excludeTags;
 import static org.junit.platform.launcher.TagFilter.includeTags;
 
+import com.github.sbt.junit.jupiter.api.JupiterLauncherConfig;
 import com.github.sbt.junit.jupiter.api.JupiterTestListener;
 import com.github.sbt.junit.jupiter.api.StreamPair;
 import com.github.sbt.junit.jupiter.internal.event.Dispatcher;
@@ -31,6 +32,7 @@ import com.github.sbt.junit.jupiter.internal.filter.GlobFilter;
 import com.github.sbt.junit.jupiter.internal.filter.TestFilter;
 import com.github.sbt.junit.jupiter.internal.listeners.OutputCapturingTestListener;
 import com.github.sbt.junit.jupiter.internal.listeners.SummaryPrintingTestListener;
+import com.github.sbt.junit.jupiter.internal.options.LauncherConfigParser;
 import com.github.sbt.junit.jupiter.internal.options.Options;
 import com.github.sbt.junit.jupiter.internal.options.OptionsParser;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import sbt.testing.EventHandler;
@@ -60,6 +63,7 @@ public class JupiterRunner implements Runner {
   private final String[] args;
   private final String[] remoteArgs;
   private final Options options;
+  private final JupiterLauncherConfig launcherConfig;
 
   public JupiterRunner(
       String[] args,
@@ -72,6 +76,7 @@ public class JupiterRunner implements Runner {
     this.testClassLoader = testClassLoader;
     this.systemStreamPair = systemStreamPair;
     this.options = new OptionsParser().parse(args);
+    this.launcherConfig = LauncherConfigParser.parse(args);
   }
 
   @Override
@@ -172,7 +177,20 @@ public class JupiterRunner implements Runner {
         builder.selectors(testSelector(testSuiteName));
         builder.filters(testFilters(dispatcher));
 
-        Launcher launcher = LauncherFactory.create();
+        final var config =
+            LauncherConfig.builder()
+                .enableTestEngineAutoRegistration(
+                    launcherConfig.testEngineAutoRegistrationEnabled())
+                .enableLauncherSessionListenerAutoRegistration(
+                    launcherConfig.launcherSessionListenerAutoRegistrationEnabled())
+                .enableLauncherDiscoveryListenerAutoRegistration(
+                    launcherConfig.launcherDiscoveryListenerAutoRegistrationEnabled())
+                .enableTestExecutionListenerAutoRegistration(
+                    launcherConfig.testExecutionListenerAutoRegistrationEnabled())
+                .enablePostDiscoveryFilterAutoRegistration(
+                    launcherConfig.postDiscoveryFilterAutoRegistrationEnabled())
+                .build();
+        final Launcher launcher = LauncherFactory.create(config);
 
         launcher.registerTestExecutionListeners(dispatcher);
         launcher.registerTestExecutionListeners(outputCapturingListener);

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParser.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParser.java
@@ -1,0 +1,70 @@
+/*
+ * jupiter-interface
+ *
+ * Copyright (c) 2017, Michael Aichler.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.sbt.junit.jupiter.internal.options;
+
+import com.github.sbt.junit.jupiter.api.JupiterLauncherConfig;
+
+/**
+ * Internal parser for the launcher-config flags injected by the sbt plugin to transport a {@link
+ * JupiterLauncherConfig} value across the JVM boundary into the test runner. These flag names are
+ * an implementation detail; the user-facing configuration path is the {@code
+ * jupiterTestRunningLauncherConfig} setting key.
+ *
+ * <p>For each flag, the LAST occurrence wins. The plugin always injects all 5 flags ahead of any
+ * user-supplied {@code testOnly --} arguments, so a user-supplied flag overrides the setting-key
+ * value for that single test run.
+ */
+public final class LauncherConfigParser {
+
+  static final String OPT_TEST_ENGINE = "--test-engine-auto-registration-enabled=";
+  static final String OPT_LAUNCHER_SESSION =
+      "--launcher-session-listener-auto-registration-enabled=";
+  static final String OPT_LAUNCHER_DISCOVERY =
+      "--launcher-discovery-listener-auto-registration-enabled=";
+  static final String OPT_TEST_EXECUTION = "--test-execution-listener-auto-registration-enabled=";
+  static final String OPT_POST_DISCOVERY = "--post-discovery-filter-auto-registration-enabled=";
+
+  public static JupiterLauncherConfig parse(String[] args) {
+
+    var testEngine = true;
+    var launcherSession = true;
+    var launcherDiscovery = true;
+    var testExecution = true;
+    var postDiscovery = true;
+
+    for (final var arg : args) {
+      if (arg.startsWith(OPT_TEST_ENGINE)) {
+        testEngine = Boolean.parseBoolean(arg.substring(OPT_TEST_ENGINE.length()));
+      } else if (arg.startsWith(OPT_LAUNCHER_SESSION)) {
+        launcherSession = Boolean.parseBoolean(arg.substring(OPT_LAUNCHER_SESSION.length()));
+      } else if (arg.startsWith(OPT_LAUNCHER_DISCOVERY)) {
+        launcherDiscovery = Boolean.parseBoolean(arg.substring(OPT_LAUNCHER_DISCOVERY.length()));
+      } else if (arg.startsWith(OPT_TEST_EXECUTION)) {
+        testExecution = Boolean.parseBoolean(arg.substring(OPT_TEST_EXECUTION.length()));
+      } else if (arg.startsWith(OPT_POST_DISCOVERY)) {
+        postDiscovery = Boolean.parseBoolean(arg.substring(OPT_POST_DISCOVERY.length()));
+      }
+    }
+
+    return new JupiterLauncherConfig(
+        testEngine, launcherSession, launcherDiscovery, testExecution, postDiscovery);
+  }
+
+  private LauncherConfigParser() {}
+}

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParser.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParser.java
@@ -19,6 +19,9 @@
 package com.github.sbt.junit.jupiter.internal.options;
 
 import com.github.sbt.junit.jupiter.api.JupiterLauncherConfig;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Internal parser for the launcher-config flags injected by the sbt plugin to transport a {@link
@@ -26,7 +29,7 @@ import com.github.sbt.junit.jupiter.api.JupiterLauncherConfig;
  * an implementation detail; the user-facing configuration path is the {@code
  * jupiterTestRunningLauncherConfig} setting key.
  *
- * <p>For each flag, the LAST occurrence wins. The plugin always injects all 5 flags ahead of any
+ * <p>For each flag, the LAST occurrence wins. The plugin always injects all flags ahead of any
  * user-supplied {@code testOnly --} arguments, so a user-supplied flag overrides the setting-key
  * value for that single test run.
  */
@@ -40,6 +43,12 @@ public final class LauncherConfigParser {
   static final String OPT_TEST_EXECUTION = "--test-execution-listener-auto-registration-enabled=";
   static final String OPT_POST_DISCOVERY = "--post-discovery-filter-auto-registration-enabled=";
 
+  static final String OPT_TEST_ENGINE_CLASSES = "--test-engine-class-names=";
+  static final String OPT_LAUNCHER_SESSION_CLASSES = "--launcher-session-listener-class-names=";
+  static final String OPT_LAUNCHER_DISCOVERY_CLASSES = "--launcher-discovery-listener-class-names=";
+  static final String OPT_TEST_EXECUTION_CLASSES = "--test-execution-listener-class-names=";
+  static final String OPT_POST_DISCOVERY_CLASSES = "--post-discovery-filter-class-names=";
+
   public static JupiterLauncherConfig parse(String[] args) {
 
     var testEngine = true;
@@ -47,6 +56,12 @@ public final class LauncherConfigParser {
     var launcherDiscovery = true;
     var testExecution = true;
     var postDiscovery = true;
+
+    var testEngineClasses = List.<String>of();
+    var launcherSessionClasses = List.<String>of();
+    var launcherDiscoveryClasses = List.<String>of();
+    var testExecutionClasses = List.<String>of();
+    var postDiscoveryClasses = List.<String>of();
 
     for (final var arg : args) {
       if (arg.startsWith(OPT_TEST_ENGINE)) {
@@ -59,11 +74,41 @@ public final class LauncherConfigParser {
         testExecution = Boolean.parseBoolean(arg.substring(OPT_TEST_EXECUTION.length()));
       } else if (arg.startsWith(OPT_POST_DISCOVERY)) {
         postDiscovery = Boolean.parseBoolean(arg.substring(OPT_POST_DISCOVERY.length()));
+      } else if (arg.startsWith(OPT_TEST_ENGINE_CLASSES)) {
+        testEngineClasses = parseList(arg.substring(OPT_TEST_ENGINE_CLASSES.length()));
+      } else if (arg.startsWith(OPT_LAUNCHER_SESSION_CLASSES)) {
+        launcherSessionClasses = parseList(arg.substring(OPT_LAUNCHER_SESSION_CLASSES.length()));
+      } else if (arg.startsWith(OPT_LAUNCHER_DISCOVERY_CLASSES)) {
+        launcherDiscoveryClasses =
+            parseList(arg.substring(OPT_LAUNCHER_DISCOVERY_CLASSES.length()));
+      } else if (arg.startsWith(OPT_TEST_EXECUTION_CLASSES)) {
+        testExecutionClasses = parseList(arg.substring(OPT_TEST_EXECUTION_CLASSES.length()));
+      } else if (arg.startsWith(OPT_POST_DISCOVERY_CLASSES)) {
+        postDiscoveryClasses = parseList(arg.substring(OPT_POST_DISCOVERY_CLASSES.length()));
       }
     }
 
     return new JupiterLauncherConfig(
-        testEngine, launcherSession, launcherDiscovery, testExecution, postDiscovery);
+        testEngine,
+        launcherSession,
+        launcherDiscovery,
+        testExecution,
+        postDiscovery,
+        testEngineClasses,
+        launcherSessionClasses,
+        launcherDiscoveryClasses,
+        testExecutionClasses,
+        postDiscoveryClasses);
+  }
+
+  private static List<String> parseList(String value) {
+    if (value.isEmpty()) {
+      return List.of();
+    }
+    return Arrays.stream(value.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toUnmodifiableList());
   }
 
   private LauncherConfigParser() {}

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfigTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfigTest.java
@@ -17,7 +17,6 @@ public class JupiterLauncherConfigTest {
 
   @Test
   public void defaultConfigBuildsJUnitConfig() {
-
     final var jUnitConfig =
         JupiterLauncherConfig.DEFAULT.toJUnitConfig(getClass().getClassLoader());
     assertThat(jUnitConfig, is(notNullValue()));
@@ -25,7 +24,6 @@ public class JupiterLauncherConfigTest {
 
   @Test
   public void registersExplicitTestEngineByFqn() {
-
     final var cfg =
         new JupiterLauncherConfig(
             false,
@@ -44,7 +42,6 @@ public class JupiterLauncherConfigTest {
 
   @Test
   public void registersExplicitTestExecutionListenerByFqn() {
-
     final var cfg =
         new JupiterLauncherConfig(
             true,
@@ -63,7 +60,6 @@ public class JupiterLauncherConfigTest {
 
   @Test
   public void unknownFqnThrowsRuntimeException() {
-
     final var cfg =
         new JupiterLauncherConfig(
             false,
@@ -83,7 +79,6 @@ public class JupiterLauncherConfigTest {
 
   @Test
   public void wrongInterfaceThrowsRuntimeException() {
-
     // NoOpTestEngine implements TestEngine, not TestExecutionListener.
     final var cfg =
         new JupiterLauncherConfig(

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfigTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/api/JupiterLauncherConfigTest.java
@@ -1,0 +1,122 @@
+package com.github.sbt.junit.jupiter.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
+
+import java.util.List;
+import org.junit.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.launcher.TestExecutionListener;
+
+public class JupiterLauncherConfigTest {
+
+  @Test
+  public void defaultConfigBuildsJUnitConfig() {
+
+    final var jUnitConfig =
+        JupiterLauncherConfig.DEFAULT.toJUnitConfig(getClass().getClassLoader());
+    assertThat(jUnitConfig, is(notNullValue()));
+  }
+
+  @Test
+  public void registersExplicitTestEngineByFqn() {
+
+    final var cfg =
+        new JupiterLauncherConfig(
+            false,
+            true,
+            true,
+            true,
+            true,
+            List.of(NoOpTestEngine.class.getName()),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
+    final var jUnitConfig = cfg.toJUnitConfig(getClass().getClassLoader());
+    assertThat(jUnitConfig, is(notNullValue()));
+  }
+
+  @Test
+  public void registersExplicitTestExecutionListenerByFqn() {
+
+    final var cfg =
+        new JupiterLauncherConfig(
+            true,
+            true,
+            true,
+            false,
+            true,
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(NoOpTestExecutionListener.class.getName()),
+            List.of());
+    final var jUnitConfig = cfg.toJUnitConfig(getClass().getClassLoader());
+    assertThat(jUnitConfig, is(notNullValue()));
+  }
+
+  @Test
+  public void unknownFqnThrowsRuntimeException() {
+
+    final var cfg =
+        new JupiterLauncherConfig(
+            false,
+            true,
+            true,
+            true,
+            true,
+            List.of("does.not.Exist"),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
+    final var ex =
+        assertThrows(RuntimeException.class, () -> cfg.toJUnitConfig(getClass().getClassLoader()));
+    assertThat(ex.getMessage(), containsString("does.not.Exist"));
+  }
+
+  @Test
+  public void wrongInterfaceThrowsRuntimeException() {
+
+    // NoOpTestEngine implements TestEngine, not TestExecutionListener.
+    final var cfg =
+        new JupiterLauncherConfig(
+            true,
+            true,
+            true,
+            false,
+            true,
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(NoOpTestEngine.class.getName()),
+            List.of());
+    final var ex =
+        assertThrows(RuntimeException.class, () -> cfg.toJUnitConfig(getClass().getClassLoader()));
+    assertThat(ex.getMessage(), containsString(NoOpTestEngine.class.getName()));
+  }
+
+  public static final class NoOpTestEngine implements TestEngine {
+    @Override
+    public String getId() {
+      return "no-op";
+    }
+
+    @Override
+    public TestDescriptor discover(
+        org.junit.platform.engine.EngineDiscoveryRequest request, UniqueId uniqueId) {
+      return new org.junit.platform.engine.support.descriptor.EngineDescriptor(uniqueId, "no-op");
+    }
+
+    @Override
+    public void execute(org.junit.platform.engine.ExecutionRequest request) {}
+  }
+
+  public static final class NoOpTestExecutionListener implements TestExecutionListener {}
+}

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParserTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParserTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import com.github.sbt.junit.jupiter.api.JupiterLauncherConfig;
+import java.util.List;
 import org.junit.Test;
 
 public class LauncherConfigParserTest {
@@ -50,7 +51,13 @@ public class LauncherConfigParserTest {
               "--test-execution-listener-auto-registration-enabled=false",
               "--post-discovery-filter-auto-registration-enabled=false"
             });
-    assertThat(cfg, is(equalTo(new JupiterLauncherConfig(false, false, false, false, false))));
+    assertThat(
+        cfg,
+        is(
+            equalTo(
+                new JupiterLauncherConfig(
+                    false, false, false, false, false, List.of(), List.of(), List.of(), List.of(),
+                    List.of()))));
   }
 
   @Test

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParserTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParserTest.java
@@ -14,14 +14,12 @@ public class LauncherConfigParserTest {
 
   @Test
   public void emptyArgsYieldDefault() {
-
     final var cfg = LauncherConfigParser.parse(new String[0]);
     assertThat(cfg, is(equalTo(JupiterLauncherConfig.DEFAULT)));
   }
 
   @Test
   public void unrelatedArgsAreIgnored() {
-
     final var cfg =
         LauncherConfigParser.parse(new String[] {"-v", "--include-tags=fast", "-Dfoo=bar"});
     assertThat(cfg, is(equalTo(JupiterLauncherConfig.DEFAULT)));
@@ -29,7 +27,6 @@ public class LauncherConfigParserTest {
 
   @Test
   public void singleFlagFlipsOnlyThatField() {
-
     final var cfg =
         LauncherConfigParser.parse(new String[] {"--test-engine-auto-registration-enabled=false"});
     assertThat(cfg.testEngineAutoRegistrationEnabled(), is(false));
@@ -41,7 +38,6 @@ public class LauncherConfigParserTest {
 
   @Test
   public void allFiveFlagsParsed() {
-
     final var cfg =
         LauncherConfigParser.parse(
             new String[] {
@@ -62,7 +58,6 @@ public class LauncherConfigParserTest {
 
   @Test
   public void lastOccurrenceWins() {
-
     final var cfg =
         LauncherConfigParser.parse(
             new String[] {
@@ -74,21 +69,18 @@ public class LauncherConfigParserTest {
 
   @Test
   public void emptyListFlagYieldsEmptyList() {
-
     final var cfg = LauncherConfigParser.parse(new String[] {"--test-engine-class-names="});
     assertThat(cfg.testEngineClassNames(), is(empty()));
   }
 
   @Test
   public void singleFqnInListFlag() {
-
     final var cfg = LauncherConfigParser.parse(new String[] {"--test-engine-class-names=foo.Bar"});
     assertThat(cfg.testEngineClassNames(), contains("foo.Bar"));
   }
 
   @Test
   public void multipleFqnsInListFlag() {
-
     final var cfg =
         LauncherConfigParser.parse(
             new String[] {"--test-execution-listener-class-names=foo.Bar,baz.Qux"});
@@ -97,7 +89,6 @@ public class LauncherConfigParserTest {
 
   @Test
   public void lastListOccurrenceWins() {
-
     final var cfg =
         LauncherConfigParser.parse(
             new String[] {

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParserTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParserTest.java
@@ -1,0 +1,65 @@
+package com.github.sbt.junit.jupiter.internal.options;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import com.github.sbt.junit.jupiter.api.JupiterLauncherConfig;
+import org.junit.Test;
+
+public class LauncherConfigParserTest {
+
+  @Test
+  public void emptyArgsYieldDefault() {
+
+    final var cfg = LauncherConfigParser.parse(new String[0]);
+    assertThat(cfg, is(equalTo(JupiterLauncherConfig.DEFAULT)));
+  }
+
+  @Test
+  public void unrelatedArgsAreIgnored() {
+
+    final var cfg =
+        LauncherConfigParser.parse(new String[] {"-v", "--include-tags=fast", "-Dfoo=bar"});
+    assertThat(cfg, is(equalTo(JupiterLauncherConfig.DEFAULT)));
+  }
+
+  @Test
+  public void singleFlagFlipsOnlyThatField() {
+
+    final var cfg =
+        LauncherConfigParser.parse(new String[] {"--test-engine-auto-registration-enabled=false"});
+    assertThat(cfg.testEngineAutoRegistrationEnabled(), is(false));
+    assertThat(cfg.launcherSessionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(cfg.launcherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(cfg.testExecutionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(cfg.postDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void allFiveFlagsParsed() {
+
+    final var cfg =
+        LauncherConfigParser.parse(
+            new String[] {
+              "--test-engine-auto-registration-enabled=false",
+              "--launcher-session-listener-auto-registration-enabled=false",
+              "--launcher-discovery-listener-auto-registration-enabled=false",
+              "--test-execution-listener-auto-registration-enabled=false",
+              "--post-discovery-filter-auto-registration-enabled=false"
+            });
+    assertThat(cfg, is(equalTo(new JupiterLauncherConfig(false, false, false, false, false))));
+  }
+
+  @Test
+  public void lastOccurrenceWins() {
+
+    final var cfg =
+        LauncherConfigParser.parse(
+            new String[] {
+              "--test-engine-auto-registration-enabled=true",
+              "--test-engine-auto-registration-enabled=false"
+            });
+    assertThat(cfg.testEngineAutoRegistrationEnabled(), is(false));
+  }
+}

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParserTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/LauncherConfigParserTest.java
@@ -1,6 +1,8 @@
 package com.github.sbt.junit.jupiter.internal.options;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -61,5 +63,39 @@ public class LauncherConfigParserTest {
               "--test-engine-auto-registration-enabled=false"
             });
     assertThat(cfg.testEngineAutoRegistrationEnabled(), is(false));
+  }
+
+  @Test
+  public void emptyListFlagYieldsEmptyList() {
+
+    final var cfg = LauncherConfigParser.parse(new String[] {"--test-engine-class-names="});
+    assertThat(cfg.testEngineClassNames(), is(empty()));
+  }
+
+  @Test
+  public void singleFqnInListFlag() {
+
+    final var cfg = LauncherConfigParser.parse(new String[] {"--test-engine-class-names=foo.Bar"});
+    assertThat(cfg.testEngineClassNames(), contains("foo.Bar"));
+  }
+
+  @Test
+  public void multipleFqnsInListFlag() {
+
+    final var cfg =
+        LauncherConfigParser.parse(
+            new String[] {"--test-execution-listener-class-names=foo.Bar,baz.Qux"});
+    assertThat(cfg.testExecutionListenerClassNames(), contains("foo.Bar", "baz.Qux"));
+  }
+
+  @Test
+  public void lastListOccurrenceWins() {
+
+    final var cfg =
+        LauncherConfigParser.parse(
+            new String[] {
+              "--test-engine-class-names=first.A", "--test-engine-class-names=second.B,third.C"
+            });
+    assertThat(cfg.testEngineClassNames(), contains("second.B", "third.C"));
   }
 }

--- a/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
@@ -132,7 +132,12 @@ object JupiterPlugin extends AutoPlugin {
     s"--launcher-session-listener-auto-registration-enabled=${cfg.launcherSessionListenerAutoRegistrationEnabled}",
     s"--launcher-discovery-listener-auto-registration-enabled=${cfg.launcherDiscoveryListenerAutoRegistrationEnabled}",
     s"--test-execution-listener-auto-registration-enabled=${cfg.testExecutionListenerAutoRegistrationEnabled}",
-    s"--post-discovery-filter-auto-registration-enabled=${cfg.postDiscoveryFilterAutoRegistrationEnabled}"
+    s"--post-discovery-filter-auto-registration-enabled=${cfg.postDiscoveryFilterAutoRegistrationEnabled}",
+    s"--test-engine-class-names=${cfg.testEngineClassNames.asScala.mkString(",")}",
+    s"--launcher-session-listener-class-names=${cfg.launcherSessionListenerClassNames.asScala.mkString(",")}",
+    s"--launcher-discovery-listener-class-names=${cfg.launcherDiscoveryListenerClassNames.asScala.mkString(",")}",
+    s"--test-execution-listener-class-names=${cfg.testExecutionListenerClassNames.asScala.mkString(",")}",
+    s"--post-discovery-filter-class-names=${cfg.postDiscoveryFilterClassNames.asScala.mkString(",")}"
   )
 
   /*

--- a/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
@@ -50,6 +50,9 @@ object Import {
     val jupiterTestDiscoveryLauncherConfig: SettingKey[JupiterLauncherConfig] =
       settingKey("Configures the JUnit Jupiter Test Discovery Launcher.")
 
+    val jupiterTestRunningLauncherConfig: SettingKey[JupiterLauncherConfig] =
+      settingKey("Configures the JUnit Jupiter Test Running Launcher.")
+
     @deprecated(message = "No longer used. Use jupiterTestDiscoveryLauncherConfig instead.", since = "0.19.0")
     val jupiterTestDiscoveryTestEngineAutoRegistrationEnabled: SettingKey[Boolean] =
       settingKey("Enable automatic registration of test engines during test discovery (default true)")
@@ -89,7 +92,8 @@ object JupiterPlugin extends AutoPlugin {
     junitPlatformVersion := readResourceProperty("jupiter-interface.properties", "junit.platform.version"),
     junitJupiterVersion := readResourceProperty("jupiter-interface.properties", "junit.jupiter.version"),
     junitVintageVersion := readResourceProperty("jupiter-interface.properties", "junit.vintage.version"),
-    jupiterTestDiscoveryLauncherConfig := JupiterLauncherConfig.DEFAULT
+    jupiterTestDiscoveryLauncherConfig := JupiterLauncherConfig.DEFAULT,
+    jupiterTestRunningLauncherConfig := JupiterLauncherConfig.DEFAULT
   ) ++ deprecatedKeyDefaults
 
   /*
@@ -116,7 +120,19 @@ object JupiterPlugin extends AutoPlugin {
    * By default this is applied to the Test configuration only.
    */
   def scopedSettings: Seq[Def.Setting[?]] = Seq(
-    definedTests ++= collectTests.value
+    definedTests ++= collectTests.value,
+    testOptions += Tests.Argument(
+      Some(jupiterTestFramework),
+      formatLauncherConfigArgs(jupiterTestRunningLauncherConfig.value).toList
+    )
+  )
+
+  private def formatLauncherConfigArgs(cfg: JupiterLauncherConfig): Seq[String] = Seq(
+    s"--test-engine-auto-registration-enabled=${cfg.testEngineAutoRegistrationEnabled}",
+    s"--launcher-session-listener-auto-registration-enabled=${cfg.launcherSessionListenerAutoRegistrationEnabled}",
+    s"--launcher-discovery-listener-auto-registration-enabled=${cfg.launcherDiscoveryListenerAutoRegistrationEnabled}",
+    s"--test-execution-listener-auto-registration-enabled=${cfg.testExecutionListenerAutoRegistrationEnabled}",
+    s"--post-discovery-filter-auto-registration-enabled=${cfg.postDiscoveryFilterAutoRegistrationEnabled}"
   )
 
   /*

--- a/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
@@ -21,6 +21,7 @@ package com.github.sbt.junit.jupiter.sbt
 import java.net.URLClassLoader
 
 import com.github.sbt.junit.jupiter.api.JupiterFramework
+import com.github.sbt.junit.jupiter.api.JupiterLauncherConfig
 import com.github.sbt.junit.jupiter.api.JupiterTestCollector
 import sbt.Keys.testFrameworks
 import sbt.Keys.*
@@ -28,6 +29,7 @@ import sbt.plugins.JvmPlugin
 import sbt.AutoPlugin
 import sbt.Def
 import sbt.*
+import scala.annotation.nowarn
 import scala.collection.JavaConverters.*
 
 object Import {
@@ -45,14 +47,22 @@ object Import {
     val junitVintageVersion: SettingKey[String] = SettingKey[String]("junit-vintage-version",
       "The JUnit Vintage version which is compatible with this plugin.")
 
+    val jupiterTestDiscoveryLauncherConfig: SettingKey[JupiterLauncherConfig] =
+      settingKey("Configures the JUnit Jupiter Test Discovery Launcher.")
+
+    @deprecated(message = "No longer used. Use jupiterTestDiscoveryLauncherConfig instead.", since = "0.19.0")
     val jupiterTestDiscoveryTestEngineAutoRegistrationEnabled: SettingKey[Boolean] =
       settingKey("Enable automatic registration of test engines during test discovery (default true)")
+    @deprecated(message = "No longer used. Use jupiterTestDiscoveryLauncherConfig instead.", since = "0.19.0")
     val jupiterTestDiscoveryLauncherSessionListenerAutoRegistrationEnabled: SettingKey[Boolean] =
       settingKey("Enable automatic registration of launcher session listeners during test discovery (default true)")
+    @deprecated(message = "No longer used. Use jupiterTestDiscoveryLauncherConfig instead.", since = "0.19.0")
     val jupiterTestDiscoveryLauncherDiscoveryListenerAutoRegistrationEnabled: SettingKey[Boolean] =
       settingKey("Enable automatic registration of launcher discovery listeners during test discovery (default true)")
+    @deprecated(message = "No longer used. Use jupiterTestDiscoveryLauncherConfig instead.", since = "0.19.0")
     val jupiterTestDiscoveryTestExecutionListenerAutoRegistrationEnabled: SettingKey[Boolean] =
       settingKey("Enable automatic registration of test execution listeners during test discovery (default true)")
+    @deprecated(message = "No longer used. Use jupiterTestDiscoveryLauncherConfig instead.", since = "0.19.0")
     val jupiterTestDiscoveryPostDiscoveryFilterAutoRegistrationEnabled: SettingKey[Boolean] =
       settingKey("Enable automatic registration of post discovery filters during test discovery (default true)")
   }
@@ -79,6 +89,16 @@ object JupiterPlugin extends AutoPlugin {
     junitPlatformVersion := readResourceProperty("jupiter-interface.properties", "junit.platform.version"),
     junitJupiterVersion := readResourceProperty("jupiter-interface.properties", "junit.jupiter.version"),
     junitVintageVersion := readResourceProperty("jupiter-interface.properties", "junit.vintage.version"),
+    jupiterTestDiscoveryLauncherConfig := JupiterLauncherConfig.DEFAULT
+  ) ++ deprecatedKeyDefaults
+
+  /*
+   * Defaults for the deprecated per-flag setting keys. They are no longer read by the plugin, but
+   * sbt requires every declared setting key to have a default to avoid undefined-setting errors on
+   * startup. `@nowarn` suppresses the deprecation warnings emitted by the LHS references.
+   */
+  @nowarn
+  private def deprecatedKeyDefaults: Seq[Def.Setting[?]] = Seq(
     jupiterTestDiscoveryTestEngineAutoRegistrationEnabled := true,
     jupiterTestDiscoveryLauncherSessionListenerAutoRegistrationEnabled := true,
     jupiterTestDiscoveryLauncherDiscoveryListenerAutoRegistrationEnabled := true,
@@ -117,11 +137,7 @@ object JupiterPlugin extends AutoPlugin {
       .withClassDirectory(classes)
       .withClassLoader(getClass.getClassLoader)
       .withRuntimeClassPath(classpath)
-      .withTestEngineAutoRegistrationEnabled(jupiterTestDiscoveryTestEngineAutoRegistrationEnabled.value)
-      .withLauncherSessionListenerAutoRegistrationEnabled(jupiterTestDiscoveryLauncherSessionListenerAutoRegistrationEnabled.value)
-      .withLauncherDiscoveryListenerAutoRegistrationEnabled(jupiterTestDiscoveryLauncherDiscoveryListenerAutoRegistrationEnabled.value)
-      .withTestExecutionListenerAutoRegistrationEnabled(jupiterTestDiscoveryTestExecutionListenerAutoRegistrationEnabled.value)
-      .withPostDiscoveryFilterAutoRegistrationEnabled(jupiterTestDiscoveryPostDiscoveryFilterAutoRegistrationEnabled.value)
+      .withLauncherConfig(jupiterTestDiscoveryLauncherConfig.value)
       .build()
 
     val discoveredTests = collector.collectTests().getDiscoveredTests.asScala.toList.map(toTestDefinition)


### PR DESCRIPTION
## Human summary

This change looks big on the surface, but it is actually a lot of boilerplate and Javadoc, so please bear with me.

This change builds on top of #226 where we added individual `Boolean` setting keys which can be used to configure specific aspects of the Jupiter Test Framework test discovery process.

The settings corresponded to specific settings in `org.junit.platform.launcher.core.LauncherConfig`. Except, `LauncherConfig` is not only applicable to the test discovery process, but also to the test running process.

Additionally, if we set some of the already exposed settings to `false` (like the auto discovery of test engines), we end up in a situation where the Jupiter Test Framework refuses to discover any tests, as there are no test engines which are configured to run. Which means that the previously exposed settings are incomplete.

Thus, there are three goals to this change.
1. Consolidate the existing individual settings into a `record` `JupiterLauncherConfig` class
2. Add more configurable settings to the config class
3. Use the same configuration class for configuring both test discovery and test execution.

## Manual testing

I manually tested the changes in the [Scala Plugin](https://github.com/JetBrains/intellij-scala) repository, which is where they're mostly needed.

## Review

If you need me to provide more details that will help with the review, I will be glad to do so.

## AI use
I used Claude Code and Claude Opus 4.7 to generate the code in this PR. However, I reviewed the code before submitting it and I stand behind it. The code is close to 100% the same as I would write it myself.

## AI Summary of the changes

  Replaces the 5 per-flag `SettingKey[Boolean]`s introduced in #226 with a unified
  `JupiterLauncherConfig` record that drives both the test-discovery side
  (`JupiterTestCollector` → already existed, now reuses the record) and the
  test-running side (`JupiterRunner` → previously called `LauncherFactory.create()`
  with no config at all). The record also lets users register SPI implementations
  explicitly by FQN — needed because disabling an auto-registration toggle would
  otherwise leave the launcher with nothing to drive.

  ## Changes

  - **New `JupiterLauncherConfig` Java record** in
    `com.github.sbt.junit.jupiter.api`. Carries:
    - the 5 existing auto-registration booleans (test engines, launcher session
      listeners, launcher discovery listeners, test execution listeners, post
      discovery filters),
    - 5 matching `List<String>` of fully qualified class names of additional
      implementations to register manually. Each FQN is loaded via the test
      classloader and instantiated through its `public` no-arg constructor at
      `LauncherConfig`-build time. Documented on the record's Javadoc.
    - `toJUnitConfig(ClassLoader)` instance method that performs the translation,
      used by both `JupiterTestCollector.collectTests0()` and
      `JupiterRunner.JupiterTaskExecutor.execute()`.

  - **Two new SettingKeys** on `JupiterPlugin`:
    - `jupiterTestDiscoveryLauncherConfig` — drives test discovery.
    - `jupiterTestRunningLauncherConfig` — drives test execution.
    Both default to `JupiterLauncherConfig.DEFAULT` (auto-register everything,
    no explicit FQNs).

  - **Test-running cross-JVM transport.** A new internal `LauncherConfigParser`
    parses the value out of the test args; the plugin injects it into the test
    JVM via `Tests.Argument`. Last-occurrence-wins, so a one-off
    `testOnly --` override takes precedence over the SettingKey for that run.
    Flag names are an internal transport, not user-facing documentation.

  - **Deprecation of #226's flat keys.** The 5 `jupiterTestDiscovery*Enabled`
    `SettingKey[Boolean]`s ship marked `@deprecated(... "0.19.0")`. They are no
    longer read by the plugin; their deprecation messages direct users to
    `jupiterTestDiscoveryLauncherConfig`. Defaults are still provided so user
    builds that reference them keep evaluating without errors.

  - **`JupiterTestCollector.Builder` gains `withLauncherConfig(...)`** — the 5
    existing per-flag setters are kept (they shipped in 0.18.0) and marked
    `@Deprecated(since = "0.19.0", forRemoval = true)` with a Javadoc pointer to
    the new setter.

  ## Test plan

  - [x] `+library/compile +plugin/compile` — Scala 2.12 + 3.8.3 cross-build clean.
  - [x] `+library/test` — 67/67 (was 53; +5 `LauncherConfigParser` tests, +5
        `JupiterLauncherConfig` tests covering default, single-FQN, multi-FQN,
        missing-FQN, and wrong-interface paths, +4 list-flag parser tests).
  - [x] `scripted basic/interface-demo basic/can-run-single-test
        basic/run-listener` — defaults path through the new pipeline.
  - [x] `++3.x scriptedTestSbt2` — sbt 2 / Scala 3 path.
  - [x] `javafmtCheckAll`.