### PR TITLE
Apply LauncherConfig settings at test runtime, plus manual-registration settings

### DIFF
--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
@@ -28,10 +28,16 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.function.IntFunction;
+import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.core.LauncherConfig;
@@ -57,6 +63,12 @@ public class JupiterTestCollector {
   private final boolean launcherDiscoveryListenerAutoRegistrationEnabled;
   private final boolean testExecutionListenerAutoRegistrationEnabled;
   private final boolean postDiscoveryFilterAutoRegistrationEnabled;
+
+  private final List<String> testEngines;
+  private final List<String> launcherSessionListeners;
+  private final List<String> launcherDiscoveryListeners;
+  private final List<String> testExecutionListeners;
+  private final List<String> postDiscoveryFilters;
 
   /**
    * Executes a JUnit Jupiter launcher discovery request.
@@ -180,6 +192,12 @@ public class JupiterTestCollector {
     private boolean testExecutionListenerAutoRegistrationEnabled = true;
     private boolean postDiscoveryFilterAutoRegistrationEnabled = true;
 
+    private List<String> testEngines = Collections.emptyList();
+    private List<String> launcherSessionListeners = Collections.emptyList();
+    private List<String> launcherDiscoveryListeners = Collections.emptyList();
+    private List<String> testExecutionListeners = Collections.emptyList();
+    private List<String> postDiscoveryFilters = Collections.emptyList();
+
     /**
      * Specifies the classloader which should be used by the collector.
      *
@@ -282,6 +300,71 @@ public class JupiterTestCollector {
     }
 
     /**
+     * Configures the Jupiter Test Discovery Launcher to manually register the given test engines,
+     * specified by fully-qualified class name. Each class must declare a public zero-argument
+     * constructor.
+     *
+     * @param value list of fully-qualified class names
+     * @return This builder.
+     */
+    public Builder withTestEngines(List<String> value) {
+      this.testEngines = value;
+      return this;
+    }
+
+    /**
+     * Configures the Jupiter Test Discovery Launcher to manually register the given launcher
+     * session listeners, specified by fully-qualified class name. Each class must declare a public
+     * zero-argument constructor.
+     *
+     * @param value list of fully-qualified class names
+     * @return This builder.
+     */
+    public Builder withLauncherSessionListeners(List<String> value) {
+      this.launcherSessionListeners = value;
+      return this;
+    }
+
+    /**
+     * Configures the Jupiter Test Discovery Launcher to manually register the given launcher
+     * discovery listeners, specified by fully-qualified class name. Each class must declare a
+     * public zero-argument constructor.
+     *
+     * @param value list of fully-qualified class names
+     * @return This builder.
+     */
+    public Builder withLauncherDiscoveryListeners(List<String> value) {
+      this.launcherDiscoveryListeners = value;
+      return this;
+    }
+
+    /**
+     * Configures the Jupiter Test Discovery Launcher to manually register the given test execution
+     * listeners, specified by fully-qualified class name. Each class must declare a public
+     * zero-argument constructor.
+     *
+     * @param value list of fully-qualified class names
+     * @return This builder.
+     */
+    public Builder withTestExecutionListeners(List<String> value) {
+      this.testExecutionListeners = value;
+      return this;
+    }
+
+    /**
+     * Configures the Jupiter Test Discovery Launcher to manually register the given post discovery
+     * filters, specified by fully-qualified class name. Each class must declare a public
+     * zero-argument constructor.
+     *
+     * @param value list of fully-qualified class names
+     * @return This builder.
+     */
+    public Builder withPostDiscoveryFilters(List<String> value) {
+      this.postDiscoveryFilters = value;
+      return this;
+    }
+
+    /**
      * Creates an instance of {@link JupiterTestCollector}.
      *
      * @return A new collector.
@@ -311,6 +394,11 @@ public class JupiterTestCollector {
         builder.testExecutionListenerAutoRegistrationEnabled;
     this.postDiscoveryFilterAutoRegistrationEnabled =
         builder.postDiscoveryFilterAutoRegistrationEnabled;
+    this.testEngines = builder.testEngines;
+    this.launcherSessionListeners = builder.launcherSessionListeners;
+    this.launcherDiscoveryListeners = builder.launcherDiscoveryListeners;
+    this.testExecutionListeners = builder.testExecutionListeners;
+    this.postDiscoveryFilters = builder.postDiscoveryFilters;
   }
 
   /**
@@ -339,6 +427,27 @@ public class JupiterTestCollector {
             .enableTestExecutionListenerAutoRegistration(
                 testExecutionListenerAutoRegistrationEnabled)
             .enablePostDiscoveryFilterAutoRegistration(postDiscoveryFilterAutoRegistrationEnabled)
+            .addTestEngines(instantiateAll(testEngines, TestEngine.class, TestEngine[]::new))
+            .addLauncherSessionListeners(
+                instantiateAll(
+                    launcherSessionListeners,
+                    LauncherSessionListener.class,
+                    LauncherSessionListener[]::new))
+            .addLauncherDiscoveryListeners(
+                instantiateAll(
+                    launcherDiscoveryListeners,
+                    LauncherDiscoveryListener.class,
+                    LauncherDiscoveryListener[]::new))
+            .addTestExecutionListeners(
+                instantiateAll(
+                    testExecutionListeners,
+                    TestExecutionListener.class,
+                    TestExecutionListener[]::new))
+            .addPostDiscoveryFilters(
+                instantiateAll(
+                    postDiscoveryFilters,
+                    PostDiscoveryFilter.class,
+                    PostDiscoveryFilter[]::new))
             .build();
 
     TestPlan testPlan = LauncherFactory.create(config).discover(request);
@@ -365,6 +474,28 @@ public class JupiterTestCollector {
     }
 
     return result;
+  }
+
+  private <T> T[] instantiateAll(
+      List<String> fqns, Class<T> type, IntFunction<T[]> arrayFactory) {
+
+    T[] instances = arrayFactory.apply(fqns.size());
+    ClassLoader loader = Thread.currentThread().getContextClassLoader();
+    for (int i = 0; i < fqns.size(); i++) {
+      String fqn = fqns.get(i);
+      try {
+        Class<?> cls = Class.forName(fqn, true, loader);
+        Object instance = cls.getConstructor().newInstance();
+        if (!type.isInstance(instance)) {
+          throw new IllegalArgumentException(
+              "'" + fqn + "' does not implement " + type.getName());
+        }
+        instances[i] = type.cast(instance);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Failed to instantiate '" + fqn + "'", e);
+      }
+    }
+    return instances;
   }
 
   /**

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/api/JupiterTestCollector.java
@@ -445,9 +445,7 @@ public class JupiterTestCollector {
                     TestExecutionListener[]::new))
             .addPostDiscoveryFilters(
                 instantiateAll(
-                    postDiscoveryFilters,
-                    PostDiscoveryFilter.class,
-                    PostDiscoveryFilter[]::new))
+                    postDiscoveryFilters, PostDiscoveryFilter.class, PostDiscoveryFilter[]::new))
             .build();
 
     TestPlan testPlan = LauncherFactory.create(config).discover(request);
@@ -476,8 +474,7 @@ public class JupiterTestCollector {
     return result;
   }
 
-  private <T> T[] instantiateAll(
-      List<String> fqns, Class<T> type, IntFunction<T[]> arrayFactory) {
+  private <T> T[] instantiateAll(List<String> fqns, Class<T> type, IntFunction<T[]> arrayFactory) {
 
     T[] instances = arrayFactory.apply(fqns.size());
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -487,8 +484,7 @@ public class JupiterTestCollector {
         Class<?> cls = Class.forName(fqn, true, loader);
         Object instance = cls.getConstructor().newInstance();
         if (!type.isInstance(instance)) {
-          throw new IllegalArgumentException(
-              "'" + fqn + "' does not implement " + type.getName());
+          throw new IllegalArgumentException("'" + fqn + "' does not implement " + type.getName());
         }
         instances[i] = type.cast(instance);
       } catch (ReflectiveOperationException e) {

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/JupiterRunner.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/JupiterRunner.java
@@ -38,9 +38,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.IntFunction;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
+import org.junit.platform.engine.TestEngine;
 import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
@@ -184,6 +189,28 @@ public class JupiterRunner implements Runner {
                     options.isTestExecutionListenerAutoRegistrationEnabled())
                 .enablePostDiscoveryFilterAutoRegistration(
                     options.isPostDiscoveryFilterAutoRegistrationEnabled())
+                .addTestEngines(
+                    instantiateAll(options.getTestEngines(), TestEngine.class, TestEngine[]::new))
+                .addLauncherSessionListeners(
+                    instantiateAll(
+                        options.getLauncherSessionListeners(),
+                        LauncherSessionListener.class,
+                        LauncherSessionListener[]::new))
+                .addLauncherDiscoveryListeners(
+                    instantiateAll(
+                        options.getLauncherDiscoveryListeners(),
+                        LauncherDiscoveryListener.class,
+                        LauncherDiscoveryListener[]::new))
+                .addTestExecutionListeners(
+                    instantiateAll(
+                        options.getTestExecutionListeners(),
+                        TestExecutionListener.class,
+                        TestExecutionListener[]::new))
+                .addPostDiscoveryFilters(
+                    instantiateAll(
+                        options.getPostDiscoveryFilters(),
+                        PostDiscoveryFilter.class,
+                        PostDiscoveryFilter[]::new))
                 .build();
 
         Launcher launcher = LauncherFactory.create(launcherConfig);
@@ -214,6 +241,27 @@ public class JupiterRunner implements Runner {
       }
 
       return selectClass(testClassName);
+    }
+
+    private <T> T[] instantiateAll(
+        List<String> fqns, Class<T> type, IntFunction<T[]> arrayFactory) {
+
+      T[] instances = arrayFactory.apply(fqns.size());
+      for (int i = 0; i < fqns.size(); i++) {
+        String fqn = fqns.get(i);
+        try {
+          Class<?> cls = Class.forName(fqn, true, testClassLoader);
+          Object instance = cls.getConstructor().newInstance();
+          if (!type.isInstance(instance)) {
+            throw new IllegalArgumentException(
+                "'" + fqn + "' does not implement " + type.getName());
+          }
+          instances[i] = type.cast(instance);
+        } catch (ReflectiveOperationException e) {
+          throw new RuntimeException("Failed to instantiate '" + fqn + "'", e);
+        }
+      }
+      return instances;
     }
 
     private Filter<?>[] testFilters(Dispatcher dispatcher) {

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/JupiterRunner.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/JupiterRunner.java
@@ -42,6 +42,7 @@ import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import sbt.testing.EventHandler;
@@ -172,7 +173,20 @@ public class JupiterRunner implements Runner {
         builder.selectors(testSelector(testSuiteName));
         builder.filters(testFilters(dispatcher));
 
-        Launcher launcher = LauncherFactory.create();
+        LauncherConfig launcherConfig =
+            LauncherConfig.builder()
+                .enableTestEngineAutoRegistration(options.isTestEngineAutoRegistrationEnabled())
+                .enableLauncherSessionListenerAutoRegistration(
+                    options.isLauncherSessionListenerAutoRegistrationEnabled())
+                .enableLauncherDiscoveryListenerAutoRegistration(
+                    options.isLauncherDiscoveryListenerAutoRegistrationEnabled())
+                .enableTestExecutionListenerAutoRegistration(
+                    options.isTestExecutionListenerAutoRegistrationEnabled())
+                .enablePostDiscoveryFilterAutoRegistration(
+                    options.isPostDiscoveryFilterAutoRegistrationEnabled())
+                .build();
+
+        Launcher launcher = LauncherFactory.create(launcherConfig);
 
         launcher.registerTestExecutionListeners(dispatcher);
         launcher.registerTestExecutionListeners(outputCapturingListener);

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/Options.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/Options.java
@@ -45,6 +45,11 @@ public class Options {
   private final boolean verbose;
   private final boolean traceDispatchEvents;
   private final boolean typesEnabled;
+  private final boolean testEngineAutoRegistrationEnabled;
+  private final boolean launcherSessionListenerAutoRegistrationEnabled;
+  private final boolean launcherDiscoveryListenerAutoRegistrationEnabled;
+  private final boolean testExecutionListenerAutoRegistrationEnabled;
+  private final boolean postDiscoveryFilterAutoRegistrationEnabled;
   private final Set<String> testFilters;
   private final List<String> includeTags;
   private final List<String> excludeTags;
@@ -73,6 +78,15 @@ public class Options {
     traceDispatchEvents = builder.traceDispatchEvents;
     typesEnabled = builder.typesEnabled;
     displayMode = builder.displayMode;
+    testEngineAutoRegistrationEnabled = builder.testEngineAutoRegistrationEnabled;
+    launcherSessionListenerAutoRegistrationEnabled =
+        builder.launcherSessionListenerAutoRegistrationEnabled;
+    launcherDiscoveryListenerAutoRegistrationEnabled =
+        builder.launcherDiscoveryListenerAutoRegistrationEnabled;
+    testExecutionListenerAutoRegistrationEnabled =
+        builder.testExecutionListenerAutoRegistrationEnabled;
+    postDiscoveryFilterAutoRegistrationEnabled =
+        builder.postDiscoveryFilterAutoRegistrationEnabled;
   }
 
   /**
@@ -198,6 +212,50 @@ public class Options {
   }
 
   /**
+   * @return {@code True}, if the JUnit Platform Launcher should auto-register test engines.
+   */
+  public boolean isTestEngineAutoRegistrationEnabled() {
+
+    return testEngineAutoRegistrationEnabled;
+  }
+
+  /**
+   * @return {@code True}, if the JUnit Platform Launcher should auto-register launcher session
+   *     listeners.
+   */
+  public boolean isLauncherSessionListenerAutoRegistrationEnabled() {
+
+    return launcherSessionListenerAutoRegistrationEnabled;
+  }
+
+  /**
+   * @return {@code True}, if the JUnit Platform Launcher should auto-register launcher discovery
+   *     listeners.
+   */
+  public boolean isLauncherDiscoveryListenerAutoRegistrationEnabled() {
+
+    return launcherDiscoveryListenerAutoRegistrationEnabled;
+  }
+
+  /**
+   * @return {@code True}, if the JUnit Platform Launcher should auto-register test execution
+   *     listeners.
+   */
+  public boolean isTestExecutionListenerAutoRegistrationEnabled() {
+
+    return testExecutionListenerAutoRegistrationEnabled;
+  }
+
+  /**
+   * @return {@code True}, if the JUnit Platform Launcher should auto-register post discovery
+   *     filters.
+   */
+  public boolean isPostDiscoveryFilterAutoRegistrationEnabled() {
+
+    return postDiscoveryFilterAutoRegistrationEnabled;
+  }
+
+  /**
    * @author Michael Aichler
    */
   static class Builder {
@@ -210,6 +268,11 @@ public class Options {
     private boolean exceptionClassLogEnabled = true;
     private boolean traceDispatchEvents = false;
     private boolean typesEnabled = false;
+    private boolean testEngineAutoRegistrationEnabled = true;
+    private boolean launcherSessionListenerAutoRegistrationEnabled = true;
+    private boolean launcherDiscoveryListenerAutoRegistrationEnabled = true;
+    private boolean testExecutionListenerAutoRegistrationEnabled = true;
+    private boolean postDiscoveryFilterAutoRegistrationEnabled = true;
     private Set<String> testFilters = new HashSet<>();
     private List<String> includeTags = new ArrayList<>();
     private List<String> excludeTags = new ArrayList<>();
@@ -305,6 +368,36 @@ public class Options {
     Builder withSystemProperty(Map.Entry<String, String> entry) {
 
       this.systemProperties.put(entry.getKey(), entry.getValue());
+      return this;
+    }
+
+    Builder withTestEngineAutoRegistrationEnabled(boolean value) {
+
+      this.testEngineAutoRegistrationEnabled = value;
+      return this;
+    }
+
+    Builder withLauncherSessionListenerAutoRegistrationEnabled(boolean value) {
+
+      this.launcherSessionListenerAutoRegistrationEnabled = value;
+      return this;
+    }
+
+    Builder withLauncherDiscoveryListenerAutoRegistrationEnabled(boolean value) {
+
+      this.launcherDiscoveryListenerAutoRegistrationEnabled = value;
+      return this;
+    }
+
+    Builder withTestExecutionListenerAutoRegistrationEnabled(boolean value) {
+
+      this.testExecutionListenerAutoRegistrationEnabled = value;
+      return this;
+    }
+
+    Builder withPostDiscoveryFilterAutoRegistrationEnabled(boolean value) {
+
+      this.postDiscoveryFilterAutoRegistrationEnabled = value;
       return this;
     }
 

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/Options.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/Options.java
@@ -50,6 +50,11 @@ public class Options {
   private final boolean launcherDiscoveryListenerAutoRegistrationEnabled;
   private final boolean testExecutionListenerAutoRegistrationEnabled;
   private final boolean postDiscoveryFilterAutoRegistrationEnabled;
+  private final List<String> testEngines;
+  private final List<String> launcherSessionListeners;
+  private final List<String> launcherDiscoveryListeners;
+  private final List<String> testExecutionListeners;
+  private final List<String> postDiscoveryFilters;
   private final Set<String> testFilters;
   private final List<String> includeTags;
   private final List<String> excludeTags;
@@ -87,6 +92,11 @@ public class Options {
         builder.testExecutionListenerAutoRegistrationEnabled;
     postDiscoveryFilterAutoRegistrationEnabled =
         builder.postDiscoveryFilterAutoRegistrationEnabled;
+    testEngines = builder.testEngines;
+    launcherSessionListeners = builder.launcherSessionListeners;
+    launcherDiscoveryListeners = builder.launcherDiscoveryListeners;
+    testExecutionListeners = builder.testExecutionListeners;
+    postDiscoveryFilters = builder.postDiscoveryFilters;
   }
 
   /**
@@ -256,6 +266,50 @@ public class Options {
   }
 
   /**
+   * @return Fully-qualified class names of test engines to manually register (might be empty).
+   */
+  public List<String> getTestEngines() {
+
+    return testEngines;
+  }
+
+  /**
+   * @return Fully-qualified class names of launcher session listeners to manually register (might
+   *     be empty).
+   */
+  public List<String> getLauncherSessionListeners() {
+
+    return launcherSessionListeners;
+  }
+
+  /**
+   * @return Fully-qualified class names of launcher discovery listeners to manually register (might
+   *     be empty).
+   */
+  public List<String> getLauncherDiscoveryListeners() {
+
+    return launcherDiscoveryListeners;
+  }
+
+  /**
+   * @return Fully-qualified class names of test execution listeners to manually register (might be
+   *     empty).
+   */
+  public List<String> getTestExecutionListeners() {
+
+    return testExecutionListeners;
+  }
+
+  /**
+   * @return Fully-qualified class names of post discovery filters to manually register (might be
+   *     empty).
+   */
+  public List<String> getPostDiscoveryFilters() {
+
+    return postDiscoveryFilters;
+  }
+
+  /**
    * @author Michael Aichler
    */
   static class Builder {
@@ -273,6 +327,11 @@ public class Options {
     private boolean launcherDiscoveryListenerAutoRegistrationEnabled = true;
     private boolean testExecutionListenerAutoRegistrationEnabled = true;
     private boolean postDiscoveryFilterAutoRegistrationEnabled = true;
+    private List<String> testEngines = new ArrayList<>();
+    private List<String> launcherSessionListeners = new ArrayList<>();
+    private List<String> launcherDiscoveryListeners = new ArrayList<>();
+    private List<String> testExecutionListeners = new ArrayList<>();
+    private List<String> postDiscoveryFilters = new ArrayList<>();
     private Set<String> testFilters = new HashSet<>();
     private List<String> includeTags = new ArrayList<>();
     private List<String> excludeTags = new ArrayList<>();
@@ -398,6 +457,36 @@ public class Options {
     Builder withPostDiscoveryFilterAutoRegistrationEnabled(boolean value) {
 
       this.postDiscoveryFilterAutoRegistrationEnabled = value;
+      return this;
+    }
+
+    Builder withTestEngines(List<String> value) {
+
+      this.testEngines.addAll(value);
+      return this;
+    }
+
+    Builder withLauncherSessionListeners(List<String> value) {
+
+      this.launcherSessionListeners.addAll(value);
+      return this;
+    }
+
+    Builder withLauncherDiscoveryListeners(List<String> value) {
+
+      this.launcherDiscoveryListeners.addAll(value);
+      return this;
+    }
+
+    Builder withTestExecutionListeners(List<String> value) {
+
+      this.testExecutionListeners.addAll(value);
+      return this;
+    }
+
+    Builder withPostDiscoveryFilters(List<String> value) {
+
+      this.postDiscoveryFilters.addAll(value);
       return this;
     }
 

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/Options.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/Options.java
@@ -90,8 +90,7 @@ public class Options {
         builder.launcherDiscoveryListenerAutoRegistrationEnabled;
     testExecutionListenerAutoRegistrationEnabled =
         builder.testExecutionListenerAutoRegistrationEnabled;
-    postDiscoveryFilterAutoRegistrationEnabled =
-        builder.postDiscoveryFilterAutoRegistrationEnabled;
+    postDiscoveryFilterAutoRegistrationEnabled = builder.postDiscoveryFilterAutoRegistrationEnabled;
     testEngines = builder.testEngines;
     launcherSessionListeners = builder.launcherSessionListeners;
     launcherDiscoveryListeners = builder.launcherDiscoveryListeners;

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/OptionsParser.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/OptionsParser.java
@@ -20,6 +20,7 @@ package com.github.sbt.junit.jupiter.internal.options;
 
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,6 +46,11 @@ public class OptionsParser {
       "--test-execution-listener-auto-registration=";
   private static final String OPT_POST_DISCOVERY_FILTER_AUTO_REGISTRATION =
       "--post-discovery-filter-auto-registration=";
+  private static final String OPT_TEST_ENGINES = "--test-engines=";
+  private static final String OPT_LAUNCHER_SESSION_LISTENERS = "--launcher-session-listeners=";
+  private static final String OPT_LAUNCHER_DISCOVERY_LISTENERS = "--launcher-discovery-listeners=";
+  private static final String OPT_TEST_EXECUTION_LISTENERS = "--test-execution-listeners=";
+  private static final String OPT_POST_DISCOVERY_FILTERS = "--post-discovery-filters=";
 
   public Options parse(String[] arguments) {
 
@@ -83,6 +89,16 @@ public class OptionsParser {
       else if (arg.startsWith(OPT_POST_DISCOVERY_FILTER_AUTO_REGISTRATION))
         builder.withPostDiscoveryFilterAutoRegistrationEnabled(
             toBool(OPT_POST_DISCOVERY_FILTER_AUTO_REGISTRATION, arg));
+      else if (arg.startsWith(OPT_TEST_ENGINES))
+        builder.withTestEngines(toList(OPT_TEST_ENGINES, arg));
+      else if (arg.startsWith(OPT_LAUNCHER_SESSION_LISTENERS))
+        builder.withLauncherSessionListeners(toList(OPT_LAUNCHER_SESSION_LISTENERS, arg));
+      else if (arg.startsWith(OPT_LAUNCHER_DISCOVERY_LISTENERS))
+        builder.withLauncherDiscoveryListeners(toList(OPT_LAUNCHER_DISCOVERY_LISTENERS, arg));
+      else if (arg.startsWith(OPT_TEST_EXECUTION_LISTENERS))
+        builder.withTestExecutionListeners(toList(OPT_TEST_EXECUTION_LISTENERS, arg));
+      else if (arg.startsWith(OPT_POST_DISCOVERY_FILTERS))
+        builder.withPostDiscoveryFilters(toList(OPT_POST_DISCOVERY_FILTERS, arg));
       else if (arg.startsWith("-D") && arg.contains("=")) builder.withSystemProperty(toEntry(arg));
       else if (!arg.startsWith("-") && !arg.startsWith("+")) builder.withGlobPattern(arg);
     }
@@ -123,6 +139,23 @@ public class OptionsParser {
         .filter(s -> !s.isEmpty())
         .map(this::stripQuotes)
         .collect(Collectors.toSet());
+  }
+
+  /**
+   * Splits a comma separated list of arguments into an order-preserving list.
+   *
+   * @param key parameter name with equal sign (e.g. --test-engines=)
+   * @param arg arg
+   */
+  private List<String> toList(String key, String arg) {
+
+    final String arguments = arg.substring(key.length());
+    final String[] values = stripQuotes(arguments).split(",");
+    return Arrays.stream(values)
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(this::stripQuotes)
+        .collect(Collectors.toList());
   }
 
   private String toValue(String key, String arg) {

--- a/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/OptionsParser.java
+++ b/src/library/src/main/java/com/github/sbt/junit/jupiter/internal/options/OptionsParser.java
@@ -35,6 +35,16 @@ public class OptionsParser {
   private static final String OPT_RUN_LISTENER = "--run-listener=";
   private static final String OPT_INCLUDE_TAGS = "--include-tags=";
   private static final String OPT_EXCLUDE_TAGS = "--exclude-tags=";
+  private static final String OPT_TEST_ENGINE_AUTO_REGISTRATION =
+      "--test-engine-auto-registration=";
+  private static final String OPT_LAUNCHER_SESSION_LISTENER_AUTO_REGISTRATION =
+      "--launcher-session-listener-auto-registration=";
+  private static final String OPT_LAUNCHER_DISCOVERY_LISTENER_AUTO_REGISTRATION =
+      "--launcher-discovery-listener-auto-registration=";
+  private static final String OPT_TEST_EXECUTION_LISTENER_AUTO_REGISTRATION =
+      "--test-execution-listener-auto-registration=";
+  private static final String OPT_POST_DISCOVERY_FILTER_AUTO_REGISTRATION =
+      "--post-discovery-filter-auto-registration=";
 
   public Options parse(String[] arguments) {
 
@@ -58,6 +68,21 @@ public class OptionsParser {
         builder.withIncludeTags(toSet(OPT_INCLUDE_TAGS, arg));
       else if (arg.startsWith(OPT_EXCLUDE_TAGS))
         builder.withExcludeTags(toSet(OPT_EXCLUDE_TAGS, arg));
+      else if (arg.startsWith(OPT_TEST_ENGINE_AUTO_REGISTRATION))
+        builder.withTestEngineAutoRegistrationEnabled(
+            toBool(OPT_TEST_ENGINE_AUTO_REGISTRATION, arg));
+      else if (arg.startsWith(OPT_LAUNCHER_SESSION_LISTENER_AUTO_REGISTRATION))
+        builder.withLauncherSessionListenerAutoRegistrationEnabled(
+            toBool(OPT_LAUNCHER_SESSION_LISTENER_AUTO_REGISTRATION, arg));
+      else if (arg.startsWith(OPT_LAUNCHER_DISCOVERY_LISTENER_AUTO_REGISTRATION))
+        builder.withLauncherDiscoveryListenerAutoRegistrationEnabled(
+            toBool(OPT_LAUNCHER_DISCOVERY_LISTENER_AUTO_REGISTRATION, arg));
+      else if (arg.startsWith(OPT_TEST_EXECUTION_LISTENER_AUTO_REGISTRATION))
+        builder.withTestExecutionListenerAutoRegistrationEnabled(
+            toBool(OPT_TEST_EXECUTION_LISTENER_AUTO_REGISTRATION, arg));
+      else if (arg.startsWith(OPT_POST_DISCOVERY_FILTER_AUTO_REGISTRATION))
+        builder.withPostDiscoveryFilterAutoRegistrationEnabled(
+            toBool(OPT_POST_DISCOVERY_FILTER_AUTO_REGISTRATION, arg));
       else if (arg.startsWith("-D") && arg.contains("=")) builder.withSystemProperty(toEntry(arg));
       else if (!arg.startsWith("-") && !arg.startsWith("+")) builder.withGlobPattern(arg);
     }
@@ -103,6 +128,15 @@ public class OptionsParser {
   private String toValue(String key, String arg) {
 
     return arg.substring(key.length());
+  }
+
+  private boolean toBool(String prefix, String arg) {
+
+    String value = arg.substring(prefix.length());
+    if ("true".equalsIgnoreCase(value)) return true;
+    if ("false".equalsIgnoreCase(value)) return false;
+    throw new IllegalArgumentException(
+        "Invalid boolean value in argument '" + arg + "': expected 'true' or 'false'");
   }
 
   private static final char DQ = '"';

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/OptionsParserTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/OptionsParserTest.java
@@ -3,6 +3,7 @@ package com.github.sbt.junit.jupiter.internal.options;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
@@ -12,42 +13,36 @@ public class OptionsParserTest {
 
   @Test
   public void toSetShouldSplitAtComma() {
-
     Options options = parse("--include-tags=development,production");
     assertThat(options.getIncludeTags(), contains("development", "production"));
   }
 
   @Test
   public void toSetShouldTrimDoubleQuotes() {
-
     Options options = parse("--include-tags=\"(development & integration)\",development");
     assertThat(options.getIncludeTags(), contains("(development & integration)", "development"));
   }
 
   @Test
   public void toSetShouldTrimSingleQuotes() {
-
     Options options = parse("--include-tags='(development & integration)'");
     assertThat(options.getIncludeTags(), contains("(development & integration)"));
   }
 
   @Test
   public void toSetShouldTrimSingleQuotesBeforeSplitting() {
-
     Options options = parse("--include-tags='(development & integration), production'");
     assertThat(options.getIncludeTags(), contains("(development & integration)", "production"));
   }
 
   @Test
   public void toSetShouldTrimDoubleQuotesBeforeSplitting() {
-
     Options options = parse("--include-tags=\"(development & integration), production\"");
     assertThat(options.getIncludeTags(), contains("(development & integration)", "production"));
   }
 
   @Test
   public void autoRegistrationDefaultsAreAllTrue() {
-
     Options options = parse();
     assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
     assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
@@ -58,7 +53,6 @@ public class OptionsParserTest {
 
   @Test
   public void disablingTestEngineAutoRegistrationLeavesOthersTrue() {
-
     Options options = parse("--test-engine-auto-registration=false");
     assertThat(options.isTestEngineAutoRegistrationEnabled(), is(false));
     assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
@@ -69,7 +63,6 @@ public class OptionsParserTest {
 
   @Test
   public void disablingLauncherSessionListenerAutoRegistrationLeavesOthersTrue() {
-
     Options options = parse("--launcher-session-listener-auto-registration=false");
     assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
     assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(false));
@@ -80,7 +73,6 @@ public class OptionsParserTest {
 
   @Test
   public void disablingLauncherDiscoveryListenerAutoRegistrationLeavesOthersTrue() {
-
     Options options = parse("--launcher-discovery-listener-auto-registration=false");
     assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
     assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
@@ -91,7 +83,6 @@ public class OptionsParserTest {
 
   @Test
   public void disablingTestExecutionListenerAutoRegistrationLeavesOthersTrue() {
-
     Options options = parse("--test-execution-listener-auto-registration=false");
     assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
     assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
@@ -102,7 +93,6 @@ public class OptionsParserTest {
 
   @Test
   public void disablingPostDiscoveryFilterAutoRegistrationLeavesOthersTrue() {
-
     Options options = parse("--post-discovery-filter-auto-registration=false");
     assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
     assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
@@ -113,7 +103,6 @@ public class OptionsParserTest {
 
   @Test
   public void explicitlyEnablingAutoRegistrationMatchesDefault() {
-
     Options options =
         parse(
             "--test-engine-auto-registration=true",
@@ -130,7 +119,6 @@ public class OptionsParserTest {
 
   @Test
   public void mixedAutoRegistrationValuesAcrossAllFiveFlags() {
-
     Options options =
         parse(
             "--test-engine-auto-registration=true",
@@ -147,7 +135,6 @@ public class OptionsParserTest {
 
   @Test
   public void autoRegistrationValueParsingIsCaseInsensitive() {
-
     Options options =
         parse(
             "--test-engine-auto-registration=False",
@@ -158,7 +145,6 @@ public class OptionsParserTest {
 
   @Test
   public void malformedAutoRegistrationValueThrowsIllegalArgumentException() {
-
     IllegalArgumentException ex =
         assertThrows(
             IllegalArgumentException.class,
@@ -168,13 +154,80 @@ public class OptionsParserTest {
 
   @Test
   public void unrecognisedFlagsDoNotAffectAutoRegistrationDefaults() {
-
     Options options = parse("-q", "--include-tags=fast", "-Dfoo=bar", "someGlob");
     assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
     assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
     assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
     assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(true));
     assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void manualRegistrationListsDefaultToEmpty() {
+    Options options = parse();
+    assertThat(options.getTestEngines(), is(empty()));
+    assertThat(options.getLauncherSessionListeners(), is(empty()));
+    assertThat(options.getLauncherDiscoveryListeners(), is(empty()));
+    assertThat(options.getTestExecutionListeners(), is(empty()));
+    assertThat(options.getPostDiscoveryFilters(), is(empty()));
+  }
+
+  @Test
+  public void testEnginesPreserveOrderWhenCommaSeparated() {
+    Options options = parse("--test-engines=a.B,c.D,e.F");
+    assertThat(options.getTestEngines(), contains("a.B", "c.D", "e.F"));
+  }
+
+  @Test
+  public void emptyManualRegistrationFlagYieldsEmptyList() {
+    Options options = parse("--test-engines=");
+    assertThat(options.getTestEngines(), is(empty()));
+  }
+
+  @Test
+  public void launcherSessionListenersFlagPopulatesOnlyItsGetter() {
+    Options options = parse("--launcher-session-listeners=a.B");
+    assertThat(options.getLauncherSessionListeners(), contains("a.B"));
+    assertThat(options.getTestEngines(), is(empty()));
+    assertThat(options.getLauncherDiscoveryListeners(), is(empty()));
+    assertThat(options.getTestExecutionListeners(), is(empty()));
+    assertThat(options.getPostDiscoveryFilters(), is(empty()));
+  }
+
+  @Test
+  public void launcherDiscoveryListenersFlagPopulatesOnlyItsGetter() {
+    Options options = parse("--launcher-discovery-listeners=a.B");
+    assertThat(options.getLauncherDiscoveryListeners(), contains("a.B"));
+    assertThat(options.getTestEngines(), is(empty()));
+    assertThat(options.getLauncherSessionListeners(), is(empty()));
+    assertThat(options.getTestExecutionListeners(), is(empty()));
+    assertThat(options.getPostDiscoveryFilters(), is(empty()));
+  }
+
+  @Test
+  public void testExecutionListenersFlagPopulatesOnlyItsGetter() {
+    Options options = parse("--test-execution-listeners=a.B");
+    assertThat(options.getTestExecutionListeners(), contains("a.B"));
+    assertThat(options.getTestEngines(), is(empty()));
+    assertThat(options.getLauncherSessionListeners(), is(empty()));
+    assertThat(options.getLauncherDiscoveryListeners(), is(empty()));
+    assertThat(options.getPostDiscoveryFilters(), is(empty()));
+  }
+
+  @Test
+  public void postDiscoveryFiltersFlagPopulatesOnlyItsGetter() {
+    Options options = parse("--post-discovery-filters=a.B");
+    assertThat(options.getPostDiscoveryFilters(), contains("a.B"));
+    assertThat(options.getTestEngines(), is(empty()));
+    assertThat(options.getLauncherSessionListeners(), is(empty()));
+    assertThat(options.getLauncherDiscoveryListeners(), is(empty()));
+    assertThat(options.getTestExecutionListeners(), is(empty()));
+  }
+
+  @Test
+  public void manualRegistrationListTrimsWhitespaceAndQuotes() {
+    Options options = parse("--test-engines=\" a.B , c.D \"");
+    assertThat(options.getTestEngines(), contains("a.B", "c.D"));
   }
 
   private static Options parse(String... args) {

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/OptionsParserTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/OptionsParserTest.java
@@ -147,8 +147,7 @@ public class OptionsParserTest {
   public void malformedAutoRegistrationValueThrowsIllegalArgumentException() {
     IllegalArgumentException ex =
         assertThrows(
-            IllegalArgumentException.class,
-            () -> parse("--test-engine-auto-registration=garbage"));
+            IllegalArgumentException.class, () -> parse("--test-engine-auto-registration=garbage"));
     assertThat(ex.getMessage(), containsString("--test-engine-auto-registration=garbage"));
   }
 

--- a/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/OptionsParserTest.java
+++ b/src/library/src/test/java/com/github/sbt/junit/jupiter/internal/options/OptionsParserTest.java
@@ -2,6 +2,9 @@ package com.github.sbt.junit.jupiter.internal.options;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
 
@@ -40,6 +43,138 @@ public class OptionsParserTest {
 
     Options options = parse("--include-tags=\"(development & integration), production\"");
     assertThat(options.getIncludeTags(), contains("(development & integration)", "production"));
+  }
+
+  @Test
+  public void autoRegistrationDefaultsAreAllTrue() {
+
+    Options options = parse();
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void disablingTestEngineAutoRegistrationLeavesOthersTrue() {
+
+    Options options = parse("--test-engine-auto-registration=false");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(false));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void disablingLauncherSessionListenerAutoRegistrationLeavesOthersTrue() {
+
+    Options options = parse("--launcher-session-listener-auto-registration=false");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(false));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void disablingLauncherDiscoveryListenerAutoRegistrationLeavesOthersTrue() {
+
+    Options options = parse("--launcher-discovery-listener-auto-registration=false");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(false));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void disablingTestExecutionListenerAutoRegistrationLeavesOthersTrue() {
+
+    Options options = parse("--test-execution-listener-auto-registration=false");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(false));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void disablingPostDiscoveryFilterAutoRegistrationLeavesOthersTrue() {
+
+    Options options = parse("--post-discovery-filter-auto-registration=false");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(false));
+  }
+
+  @Test
+  public void explicitlyEnablingAutoRegistrationMatchesDefault() {
+
+    Options options =
+        parse(
+            "--test-engine-auto-registration=true",
+            "--launcher-session-listener-auto-registration=true",
+            "--launcher-discovery-listener-auto-registration=true",
+            "--test-execution-listener-auto-registration=true",
+            "--post-discovery-filter-auto-registration=true");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void mixedAutoRegistrationValuesAcrossAllFiveFlags() {
+
+    Options options =
+        parse(
+            "--test-engine-auto-registration=true",
+            "--launcher-session-listener-auto-registration=false",
+            "--launcher-discovery-listener-auto-registration=true",
+            "--test-execution-listener-auto-registration=false",
+            "--post-discovery-filter-auto-registration=true");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(false));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(false));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void autoRegistrationValueParsingIsCaseInsensitive() {
+
+    Options options =
+        parse(
+            "--test-engine-auto-registration=False",
+            "--launcher-session-listener-auto-registration=TRUE");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(false));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
+  }
+
+  @Test
+  public void malformedAutoRegistrationValueThrowsIllegalArgumentException() {
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> parse("--test-engine-auto-registration=garbage"));
+    assertThat(ex.getMessage(), containsString("--test-engine-auto-registration=garbage"));
+  }
+
+  @Test
+  public void unrecognisedFlagsDoNotAffectAutoRegistrationDefaults() {
+
+    Options options = parse("-q", "--include-tags=fast", "-Dfoo=bar", "someGlob");
+    assertThat(options.isTestEngineAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherSessionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isLauncherDiscoveryListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isTestExecutionListenerAutoRegistrationEnabled(), is(true));
+    assertThat(options.isPostDiscoveryFilterAutoRegistrationEnabled(), is(true));
   }
 
   private static Options parse(String... args) {

--- a/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
@@ -45,16 +45,16 @@ object Import {
     val junitVintageVersion: SettingKey[String] = SettingKey[String]("junit-vintage-version",
       "The JUnit Vintage version which is compatible with this plugin.")
 
-    val jupiterTestDiscoveryTestEngineAutoRegistrationEnabled: SettingKey[Boolean] =
-      settingKey("Enable automatic registration of test engines during test discovery (default true)")
-    val jupiterTestDiscoveryLauncherSessionListenerAutoRegistrationEnabled: SettingKey[Boolean] =
-      settingKey("Enable automatic registration of launcher session listeners during test discovery (default true)")
-    val jupiterTestDiscoveryLauncherDiscoveryListenerAutoRegistrationEnabled: SettingKey[Boolean] =
-      settingKey("Enable automatic registration of launcher discovery listeners during test discovery (default true)")
-    val jupiterTestDiscoveryTestExecutionListenerAutoRegistrationEnabled: SettingKey[Boolean] =
-      settingKey("Enable automatic registration of test execution listeners during test discovery (default true)")
-    val jupiterTestDiscoveryPostDiscoveryFilterAutoRegistrationEnabled: SettingKey[Boolean] =
-      settingKey("Enable automatic registration of post discovery filters during test discovery (default true)")
+    val jupiterTestEngineAutoRegistrationEnabled: SettingKey[Boolean] =
+      settingKey("Enable automatic registration of test engines (default true)")
+    val jupiterLauncherSessionListenerAutoRegistrationEnabled: SettingKey[Boolean] =
+      settingKey("Enable automatic registration of launcher session listeners (default true)")
+    val jupiterLauncherDiscoveryListenerAutoRegistrationEnabled: SettingKey[Boolean] =
+      settingKey("Enable automatic registration of launcher discovery listeners (default true)")
+    val jupiterTestExecutionListenerAutoRegistrationEnabled: SettingKey[Boolean] =
+      settingKey("Enable automatic registration of test execution listeners (default true)")
+    val jupiterPostDiscoveryFilterAutoRegistrationEnabled: SettingKey[Boolean] =
+      settingKey("Enable automatic registration of post discovery filters (default true)")
   }
 }
 
@@ -79,11 +79,11 @@ object JupiterPlugin extends AutoPlugin {
     junitPlatformVersion := readResourceProperty("jupiter-interface.properties", "junit.platform.version"),
     junitJupiterVersion := readResourceProperty("jupiter-interface.properties", "junit.jupiter.version"),
     junitVintageVersion := readResourceProperty("jupiter-interface.properties", "junit.vintage.version"),
-    jupiterTestDiscoveryTestEngineAutoRegistrationEnabled := true,
-    jupiterTestDiscoveryLauncherSessionListenerAutoRegistrationEnabled := true,
-    jupiterTestDiscoveryLauncherDiscoveryListenerAutoRegistrationEnabled := true,
-    jupiterTestDiscoveryTestExecutionListenerAutoRegistrationEnabled := true,
-    jupiterTestDiscoveryPostDiscoveryFilterAutoRegistrationEnabled := true
+    jupiterTestEngineAutoRegistrationEnabled := true,
+    jupiterLauncherSessionListenerAutoRegistrationEnabled := true,
+    jupiterLauncherDiscoveryListenerAutoRegistrationEnabled := true,
+    jupiterTestExecutionListenerAutoRegistrationEnabled := true,
+    jupiterPostDiscoveryFilterAutoRegistrationEnabled := true
   )
 
   override def projectSettings: Seq[Def.Setting[?]] = inConfig(Test)(scopedSettings) ++ unscopedSettings
@@ -117,11 +117,11 @@ object JupiterPlugin extends AutoPlugin {
       .withClassDirectory(classes)
       .withClassLoader(getClass.getClassLoader)
       .withRuntimeClassPath(classpath)
-      .withTestEngineAutoRegistrationEnabled(jupiterTestDiscoveryTestEngineAutoRegistrationEnabled.value)
-      .withLauncherSessionListenerAutoRegistrationEnabled(jupiterTestDiscoveryLauncherSessionListenerAutoRegistrationEnabled.value)
-      .withLauncherDiscoveryListenerAutoRegistrationEnabled(jupiterTestDiscoveryLauncherDiscoveryListenerAutoRegistrationEnabled.value)
-      .withTestExecutionListenerAutoRegistrationEnabled(jupiterTestDiscoveryTestExecutionListenerAutoRegistrationEnabled.value)
-      .withPostDiscoveryFilterAutoRegistrationEnabled(jupiterTestDiscoveryPostDiscoveryFilterAutoRegistrationEnabled.value)
+      .withTestEngineAutoRegistrationEnabled(jupiterTestEngineAutoRegistrationEnabled.value)
+      .withLauncherSessionListenerAutoRegistrationEnabled(jupiterLauncherSessionListenerAutoRegistrationEnabled.value)
+      .withLauncherDiscoveryListenerAutoRegistrationEnabled(jupiterLauncherDiscoveryListenerAutoRegistrationEnabled.value)
+      .withTestExecutionListenerAutoRegistrationEnabled(jupiterTestExecutionListenerAutoRegistrationEnabled.value)
+      .withPostDiscoveryFilterAutoRegistrationEnabled(jupiterPostDiscoveryFilterAutoRegistrationEnabled.value)
       .build()
 
     val discoveredTests = collector.collectTests().getDiscoveredTests.asScala.toList.map(toTestDefinition)

--- a/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
@@ -96,7 +96,13 @@ object JupiterPlugin extends AutoPlugin {
    * By default this is applied to the Test configuration only.
    */
   def scopedSettings: Seq[Def.Setting[?]] = Seq(
-    definedTests ++= collectTests.value
+    definedTests ++= collectTests.value,
+    testOptions += Tests.Argument(jupiterTestFramework,
+      s"--test-engine-auto-registration=${jupiterTestEngineAutoRegistrationEnabled.value}",
+      s"--launcher-session-listener-auto-registration=${jupiterLauncherSessionListenerAutoRegistrationEnabled.value}",
+      s"--launcher-discovery-listener-auto-registration=${jupiterLauncherDiscoveryListenerAutoRegistrationEnabled.value}",
+      s"--test-execution-listener-auto-registration=${jupiterTestExecutionListenerAutoRegistrationEnabled.value}",
+      s"--post-discovery-filter-auto-registration=${jupiterPostDiscoveryFilterAutoRegistrationEnabled.value}")
   )
 
   /*

--- a/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
+++ b/src/plugin/src/main/scala/com/github/sbt/junit/jupiter/sbt/JupiterPlugin.scala
@@ -55,6 +55,17 @@ object Import {
       settingKey("Enable automatic registration of test execution listeners (default true)")
     val jupiterPostDiscoveryFilterAutoRegistrationEnabled: SettingKey[Boolean] =
       settingKey("Enable automatic registration of post discovery filters (default true)")
+
+    val jupiterTestEngines: SettingKey[Seq[String]] =
+      settingKey("Fully-qualified class names of TestEngine implementations to manually register (default empty)")
+    val jupiterLauncherSessionListeners: SettingKey[Seq[String]] =
+      settingKey("Fully-qualified class names of LauncherSessionListener implementations to manually register (default empty)")
+    val jupiterLauncherDiscoveryListeners: SettingKey[Seq[String]] =
+      settingKey("Fully-qualified class names of LauncherDiscoveryListener implementations to manually register (default empty)")
+    val jupiterTestExecutionListeners: SettingKey[Seq[String]] =
+      settingKey("Fully-qualified class names of TestExecutionListener implementations to manually register (default empty)")
+    val jupiterPostDiscoveryFilters: SettingKey[Seq[String]] =
+      settingKey("Fully-qualified class names of PostDiscoveryFilter implementations to manually register (default empty)")
   }
 }
 
@@ -83,7 +94,12 @@ object JupiterPlugin extends AutoPlugin {
     jupiterLauncherSessionListenerAutoRegistrationEnabled := true,
     jupiterLauncherDiscoveryListenerAutoRegistrationEnabled := true,
     jupiterTestExecutionListenerAutoRegistrationEnabled := true,
-    jupiterPostDiscoveryFilterAutoRegistrationEnabled := true
+    jupiterPostDiscoveryFilterAutoRegistrationEnabled := true,
+    jupiterTestEngines := Seq.empty[String],
+    jupiterLauncherSessionListeners := Seq.empty[String],
+    jupiterLauncherDiscoveryListeners := Seq.empty[String],
+    jupiterTestExecutionListeners := Seq.empty[String],
+    jupiterPostDiscoveryFilters := Seq.empty[String]
   )
 
   override def projectSettings: Seq[Def.Setting[?]] = inConfig(Test)(scopedSettings) ++ unscopedSettings
@@ -102,7 +118,12 @@ object JupiterPlugin extends AutoPlugin {
       s"--launcher-session-listener-auto-registration=${jupiterLauncherSessionListenerAutoRegistrationEnabled.value}",
       s"--launcher-discovery-listener-auto-registration=${jupiterLauncherDiscoveryListenerAutoRegistrationEnabled.value}",
       s"--test-execution-listener-auto-registration=${jupiterTestExecutionListenerAutoRegistrationEnabled.value}",
-      s"--post-discovery-filter-auto-registration=${jupiterPostDiscoveryFilterAutoRegistrationEnabled.value}")
+      s"--post-discovery-filter-auto-registration=${jupiterPostDiscoveryFilterAutoRegistrationEnabled.value}",
+      s"--test-engines=${jupiterTestEngines.value.mkString(",")}",
+      s"--launcher-session-listeners=${jupiterLauncherSessionListeners.value.mkString(",")}",
+      s"--launcher-discovery-listeners=${jupiterLauncherDiscoveryListeners.value.mkString(",")}",
+      s"--test-execution-listeners=${jupiterTestExecutionListeners.value.mkString(",")}",
+      s"--post-discovery-filters=${jupiterPostDiscoveryFilters.value.mkString(",")}")
   )
 
   /*
@@ -128,6 +149,11 @@ object JupiterPlugin extends AutoPlugin {
       .withLauncherDiscoveryListenerAutoRegistrationEnabled(jupiterLauncherDiscoveryListenerAutoRegistrationEnabled.value)
       .withTestExecutionListenerAutoRegistrationEnabled(jupiterTestExecutionListenerAutoRegistrationEnabled.value)
       .withPostDiscoveryFilterAutoRegistrationEnabled(jupiterPostDiscoveryFilterAutoRegistrationEnabled.value)
+      .withTestEngines(jupiterTestEngines.value.asJava)
+      .withLauncherSessionListeners(jupiterLauncherSessionListeners.value.asJava)
+      .withLauncherDiscoveryListeners(jupiterLauncherDiscoveryListeners.value.asJava)
+      .withTestExecutionListeners(jupiterTestExecutionListeners.value.asJava)
+      .withPostDiscoveryFilters(jupiterPostDiscoveryFilters.value.asJava)
       .build()
 
     val discoveredTests = collector.collectTests().getDiscoveredTests.asScala.toList.map(toTestDefinition)

--- a/src/plugin/src/sbt-test/basic/manual-test-engine-registration/build.sbt
+++ b/src/plugin/src/sbt-test/basic/manual-test-engine-registration/build.sbt
@@ -10,7 +10,7 @@ JupiterKeys.jupiterTestEngines := Seq("org.junit.jupiter.engine.JupiterTestEngin
 
 InputKey[Unit]("tests-executed") := {
   val expected = Def.spaceDelimited("<test-classes>").parsed
-  val testsrun = IO.readLines(target.value / "testsrun").toSet
+  val testsrun = IO.readLines(baseDirectory.value / "testsrun").toSet
   expected.foreach { test =>
     if (!testsrun(test)) {
       throw new RuntimeException("Expected test " + test + " to be run, but it wasn't.  Tests that were run:\n" + testsrun.mkString("\n"))
@@ -25,7 +25,7 @@ InputKey[Unit]("tests-executed") := {
 
 InputKey[Unit]("tests-not-executed") := {
   val notExpected = Def.spaceDelimited("<test-classes>").parsed
-  val testsrun = IO.readLines(target.value / "testsrun").toSet
+  val testsrun = IO.readLines(baseDirectory.value / "testsrun").toSet
   notExpected.foreach { test =>
     if (testsrun(test)) {
       throw new RuntimeException("Expected test " + test + " not to be run, but it was.  Tests that were run:\n" + testsrun.mkString("\n"))

--- a/src/plugin/src/sbt-test/basic/manual-test-engine-registration/build.sbt
+++ b/src/plugin/src/sbt-test/basic/manual-test-engine-registration/build.sbt
@@ -1,0 +1,34 @@
+name := "test-project"
+libraryDependencies ++= Seq(
+  "com.github.sbt.junit" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
+  "org.junit.vintage" % "junit-vintage-engine" % JupiterKeys.junitVintageVersion.value % Test,
+  "junit" % "junit" % "4.13.2" % Test,
+)
+
+JupiterKeys.jupiterTestEngineAutoRegistrationEnabled := false
+JupiterKeys.jupiterTestEngines := Seq("org.junit.jupiter.engine.JupiterTestEngine")
+
+InputKey[Unit]("tests-executed") := {
+  val expected = Def.spaceDelimited("<test-classes>").parsed
+  val testsrun = IO.readLines(target.value / "testsrun").toSet
+  expected.foreach { test =>
+    if (!testsrun(test)) {
+      throw new RuntimeException("Expected test " + test + " to be run, but it wasn't.  Tests that were run:\n" + testsrun.mkString("\n"))
+    }
+  }
+
+  val unexpected = testsrun filterNot expected.contains
+  if (unexpected.nonEmpty) {
+    throw new RuntimeException("Unexpected tests were run:\n" + unexpected.mkString("\n"))
+  }
+}
+
+InputKey[Unit]("tests-not-executed") := {
+  val notExpected = Def.spaceDelimited("<test-classes>").parsed
+  val testsrun = IO.readLines(target.value / "testsrun").toSet
+  notExpected.foreach { test =>
+    if (testsrun(test)) {
+      throw new RuntimeException("Expected test " + test + " not to be run, but it was.  Tests that were run:\n" + testsrun.mkString("\n"))
+    }
+  }
+}

--- a/src/plugin/src/sbt-test/basic/manual-test-engine-registration/project/plugins.sbt
+++ b/src/plugin/src/sbt-test/basic/manual-test-engine-registration/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % sys.props("project.version"))

--- a/src/plugin/src/sbt-test/basic/manual-test-engine-registration/src/test/java/sample/Junit4Test.java
+++ b/src/plugin/src/sbt-test/basic/manual-test-engine-registration/src/test/java/sample/Junit4Test.java
@@ -1,0 +1,11 @@
+package sample;
+
+import org.junit.Test;
+
+public class Junit4Test {
+
+    @Test
+    public void shouldNotRun() {
+        Reporter.report("junit4-test");
+    }
+}

--- a/src/plugin/src/sbt-test/basic/manual-test-engine-registration/src/test/java/sample/JupiterTest.java
+++ b/src/plugin/src/sbt-test/basic/manual-test-engine-registration/src/test/java/sample/JupiterTest.java
@@ -1,0 +1,11 @@
+package sample;
+
+import org.junit.jupiter.api.Test;
+
+class JupiterTest {
+
+    @Test
+    void shouldRun() {
+        Reporter.report("jupiter-test");
+    }
+}

--- a/src/plugin/src/sbt-test/basic/manual-test-engine-registration/src/test/java/sample/Reporter.java
+++ b/src/plugin/src/sbt-test/basic/manual-test-engine-registration/src/test/java/sample/Reporter.java
@@ -1,0 +1,15 @@
+package sample;
+
+import java.io.*;
+
+public class Reporter {
+    public static synchronized void report(String name) {
+        try {
+            Writer writer = new FileWriter("target/testsrun", true);
+            writer.write(name + "\n");
+            writer.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/plugin/src/sbt-test/basic/manual-test-engine-registration/src/test/java/sample/Reporter.java
+++ b/src/plugin/src/sbt-test/basic/manual-test-engine-registration/src/test/java/sample/Reporter.java
@@ -5,7 +5,7 @@ import java.io.*;
 public class Reporter {
     public static synchronized void report(String name) {
         try {
-            Writer writer = new FileWriter("target/testsrun", true);
+            Writer writer = new FileWriter("testsrun", true);
             writer.write(name + "\n");
             writer.close();
         } catch (Exception e) {

--- a/src/plugin/src/sbt-test/basic/manual-test-engine-registration/test
+++ b/src/plugin/src/sbt-test/basic/manual-test-engine-registration/test
@@ -1,0 +1,6 @@
+# Auto-registration of test engines is disabled and only the Jupiter
+# engine is registered manually. The Vintage engine is on the classpath
+# but should not load, so the JUnit 4 test must not run.
+> test
+> testsExecuted jupiter-test
+> testsNotExecuted junit4-test


### PR DESCRIPTION
#239 once again, but with the changes discussed in the comment thread: https://github.com/sbt/sbt-jupiter-interface/pull/239#discussion_r3185946006.

We've decided to rename the 5 keys added in #226 without attempting to preserve binary compatibility. The same keys are now used to configure the test discovery and the test running processes.

This PR also adds 5 more missing settings keys, which allow users to manually register test engines and various Jupiter listeners.

## AI use
I used Claude Code and Claude Opus 4.7 to generate the code in this PR. However, I reviewed the code before submitting it and I stand behind it.

## Summary

  - Renames the 5 `jupiterTestDiscoveryXxxAutoRegistrationEnabled` setting keys (added in #226) to `jupiterXxxAutoRegistrationEnabled`, since they now apply to both phases.
  - Wires the renamed settings into the test runtime path: `JupiterRunner` builds a `LauncherConfig` from these toggles before creating the `Launcher`, instead of calling `LauncherFactory.create()`. The
  plugin forwards each setting value as a `--xxx-auto-registration=<bool>` flag via `Tests.Argument`. Parsing lives in the existing `OptionsParser` with a strict boolean check that rejects anything other
  than `true`/`false` (case-insensitive).
  - Adds 5 new `SettingKey[Seq[String]]` settings for manually registering specific implementations by fully-qualified class name: `jupiterTestEngines`, `jupiterLauncherSessionListeners`,
  `jupiterLauncherDiscoveryListeners`, `jupiterTestExecutionListeners`, `jupiterPostDiscoveryFilters`. Each FQN is loaded via `Class.forName(fqn, true, loader)` and instantiated through its public
  zero-argument constructor; the resulting instances are passed to `LauncherConfig.Builder.addXxx(...)` on both the discovery (`JupiterTestCollector`) and runtime (`JupiterRunner`) paths.
  - Adds a `basic/manual-test-engine-registration` scripted test that disables auto-registration of test engines and manually registers only the Jupiter engine. A JUnit 4 test class is on the classpath
  alongside `junit-vintage-engine`, but the Vintage engine never loads so the JUnit 4 test never runs — the assertion confirms only the Jupiter test executes.
  - Defaults match JUnit Platform's own defaults (auto-registration on, no manual registrations) so existing projects see no behaviour change.

  Supersedes #239.

  ## Test plan

  - [x] `sbt clean compile Test/compile`
  - [x] `sbt library/test plugin/test` — 72 passed, 1 ignored
  - [x] `sbt plugin/scripted` — full scripted suite green, including the new `basic/manual-test-engine-registration` scenario